### PR TITLE
security: fix v0.4.x audit findings (access control, OAuth, realtime, SQL injection, deployment)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,11 @@ target_link_libraries(mantisbase
         spdlog::spdlog
 )
 
+if(WIN32)
+    # ShellExecuteA() is used to open the admin setup URL on first boot.
+    target_link_libraries(mantisbase PRIVATE shell32)
+endif()
+
 # Mirror compile environment from static target to shared target
 if(TARGET mantisbase-dll)
     get_target_property(_mb_libs mantisbase LINK_LIBRARIES)

--- a/doc/api.md
+++ b/doc/api.md
@@ -575,7 +575,7 @@ The settings object contains the following fields:
 | `orgName` | string | `"ACME Corp"` | Organization display name |
 | `siteDomain` | string | `"https://acme.example.com"` | Public site URL (OAuth callbacks, JWT audience) |
 | `corsAllowedOrigins` | array of strings | `["http://localhost:3000", "http://127.0.0.1:3000"]` | Browser origins allowed for cross-origin requests with credentials |
-| `maxFileSize` | integer | `10485760` | Max file upload size in bytes (10 MiB; not currently enforced) |
+| `maxFileSize` | integer | `10485760` | Max file upload size in bytes (10 MiB). Uploads above this are rejected with **413** |
 | `logRetentionDays` | integer | `5` | Delete application logs older than this many days (hourly cleanup job) |
 | `disableAdminRegistration` | boolean | `false` | When **true**, blocks creating new admin accounts via the API (`POST /api/v1/sys/admins`, `POST /api/v1/sys/admins/setup`) with **503**. When false or unset, admin API registration is allowed. Does not affect `mantisbase admins --add`. |
 | `disableSchemaMutations` | boolean | `false` | When **true**, blocks schema mutations via the API (`POST`, `PATCH`, `DELETE` on `/api/v1/schemas/*`) with **503**. `GET` remains available. Does not affect `mantisbase schema` CLI commands. |
@@ -912,14 +912,16 @@ WS /api/v1/realtime/ws
 
 ### Connection
 
-Connect via any WebSocket client:
+The endpoint **requires authentication**. Supply a JWT or an API key (`mb_sk_...`) either
+as a `token` query parameter or in an `Authorization: Bearer <token>` header. Unauthenticated
+connections are closed immediately with a policy-violation close code.
 
 ```javascript
-const ws = new WebSocket("ws://localhost:7070/api/v1/realtime/ws");
+const ws = new WebSocket("ws://localhost:7070/api/v1/realtime/ws?token=" + token);
 
 ws.onopen = () => {
   // Subscribe to topics after connecting
-  ws.send(JSON.stringify({ topics: ["posts", "users"] }));
+  ws.send(JSON.stringify({ type: "subscribe", topics: ["posts", "users"] }));
 };
 
 ws.onmessage = (event) => {
@@ -941,10 +943,18 @@ On connect, the server sends:
 
 ### Subscribing and unsubscribing
 
-Send a JSON message with a `topics` array to update your subscriptions. Topics follow the same format as the SSE endpoint — entity name or `entity:row_id`. Send an empty array to clear all subscriptions.
+Send a JSON message with `"type": "subscribe"` (or `"unsubscribe"`) and a `topics` array. Topics follow the same format as the SSE endpoint — entity name or `entity:row_id`.
 
 ```json
-{ "topics": ["posts", "comments", "posts:019c1b81-364b-7000-8120-b5416b2c42c2"] }
+{ "type": "subscribe", "topics": ["posts", "comments", "posts:019c1b81-364b-7000-8120-b5416b2c42c2"] }
+```
+
+Each requested topic is checked against the entity's **list** access rule. Topics you are not
+allowed to read are silently dropped, and the `subscribed` acknowledgement echoes back only the
+topics that were actually granted:
+
+```json
+{ "type": "subscribed", "topics": ["posts"] }
 ```
 
 ### Change events

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -18,15 +18,15 @@ The repository includes a `Dockerfile` in the `/docker` directory. To build and 
 
 ```bash
 # Build (optionally set MB_VERSION for a specific release)
-docker build -t mantisbase -f docker/Dockerfile --build-arg MB_VERSION=0.3.4 .
-docker run -p 7070:80 --rm mantisbase
+docker build -t mantisbase -f docker/Dockerfile --build-arg MB_VERSION=0.4.0 .
+docker run -p 7070:8080 --rm mantisbase
 ```
 
-This builds the image and starts the container, exposing MantisBase on port `80`. Pass environment variables with `-e`:
+This builds the image and starts the container, exposing MantisBase on port `8080`. Pass environment variables with `-e`:
 
 ```bash
-docker run -p 7070:80 \
-  -e MB_JWT_SECRET=your-secret-key-here \
+docker run -p 7070:8080 \
+  -e MB_JWT_SECRET="$(openssl rand -base64 48)" \
   -v $(pwd)/data:/mb/data \
   -v $(pwd)/public:/mb/public \
   -v $(pwd)/scripts:/mb/scripts \
@@ -44,7 +44,7 @@ By default, container restarts will clear all data. To persist data, mount volum
 **Example with volumes:**
 
 ```bash
-docker run -p 7070:80 \
+docker run -p 7070:8080 \
   -v $(pwd)/data:/mb/data \
   -v $(pwd)/public:/mb/public \
   -v $(pwd)/scripts:/mb/scripts \
@@ -59,11 +59,24 @@ A `docker-compose.yaml` file is provided for easier management:
 
 ```bash
 cd docker
-# Optional: set MB_JWT_SECRET and MB_VERSION in .env or export before running
+# Required: set MB_JWT_SECRET in .env or export before running
+# Example: echo "MB_JWT_SECRET=$(openssl rand -base64 48)" > .env
 docker compose -f docker-compose.yaml up --build
 ```
 
-This builds the image (using `MB_VERSION` build arg, default `0.3.4`) and starts the container with volume mounts configured. Set `MB_JWT_SECRET` and other `MB_*` variables in a `.env` file in the same directory or pass them when running `docker compose`.
+This builds the image (using `MB_VERSION` build arg, default `0.4.0`) and starts the container with volume mounts configured. `MB_JWT_SECRET` **must** be set outside dev mode - the server refuses to start without it. Set it and any other `MB_*` variables in a `.env` file in the same directory, or pass them when running `docker compose`.
+
+---
+
+## Container Hardening
+
+The shipped image and compose file apply a few defaults worth knowing about:
+
+- **Non-root**: the container runs as the unprivileged `mantisbase` user, so it listens on `8080` rather than `80`. Publish it wherever you like (`-p 7070:8080`).
+- **Read-only root filesystem**: `docker-compose.yaml` sets `read_only: true` with a `tmpfs` for `/tmp`; only the mounted `./data` volume is writable. `./www`, `./scripts` and `./migrations` are mounted read-only.
+- **No privilege escalation**: `security_opt: [no-new-privileges:true]`, plus memory/CPU limits and a file-descriptor `ulimit`.
+- **Optional release pinning**: `docker build --build-arg MB_SHA256=<sha256 of the release zip>` verifies the downloaded archive before it is unpacked.
+- **Upload limits**: the `maxFileSize` app setting (bytes, default `10485760`) is enforced at upload time, and uploads are restricted to an allow-list of file extensions.
 
 ---
 
@@ -74,17 +87,18 @@ You can configure MantisBase using environment variables or by mounting a config
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `MB_JWT_SECRET` | JWT secret key for token signing. **Required in production** (server refuses to start without it when not in dev mode) | (dev mode fallback only) |
-| `MB_VERSION` | Build-time only: release version to download (Dockerfile `ARG`) | `0.3.4` |
+| `MB_VERSION` | Build-time only: release version to download (Dockerfile `ARG`) | `0.4.0` |
 | `MB_DISABLE_FILE_UPLOADS` | Set to `1` to disable file uploads (returns 403 on upload attempts) | `0` |
 | `MB_DISABLE_ADMIN_ON_FIRST_BOOT` | Set to `1` to skip creating admin on first boot | `0` |
-| `MB_DISABLE_RATE_LIMIT` | Set to `1` to disable rate limiting | (enabled) |
+| `MB_DISABLE_RATE_LIMIT` | Set to `1` to disable rate limiting. **Only honoured in `--dev` mode**; ignored otherwise | (enabled) |
 | `MB_LOG_LEVEL` | Logging verbosity: `trace`, `debug`, `info`, `warn`, `critical` | `info` |
 | `MB_DATABASE_TYPE` | Database type: `sqlite3`, `postgresql` | `sqlite3` |
 | `MB_DATABASE_URL` | Database connection string (for PostgreSQL) | — |
 | `MB_SKIP_ADMIN_SETUP` | Set to `1` to skip the first-boot admin setup prompt | `0` |
 | `MB_DEFAULT_ADMIN_EMAIL` | Admin email for `admins --add` when no positional args given | — |
 | `MB_DEFAULT_ADMIN_PASSWORD` | Admin password for `admins --add` when no positional args given | — |
-| `MB_OAUTH_ENCRYPTION_KEY` | Encryption key for OAuth client secrets (32 chars; falls back to `MB_JWT_SECRET` padded to 32) | — |
+| `MB_OAUTH_ENCRYPTION_KEY` | Encryption key for OAuth client secrets. **Required when OAuth is used** (at least 32 chars). No longer falls back to `MB_JWT_SECRET`, so the token-signing key and the secret-at-rest key stay separate | — |
+| `MB_TRUSTED_PROXIES` | Comma-separated list of reverse-proxy IPs whose `X-Forwarded-For` header is trusted for client-IP resolution. **If unset, `X-Forwarded-For` is ignored** and the direct peer address is used, so rate limits cannot be bypassed by spoofing the header. Set this when running behind a proxy or load balancer | — |
 | `MB_REALTIME_SSE` | Set to `"false"` to disable the SSE realtime endpoint (returns 503) | enabled |
 | `MB_REALTIME_WS` | Set to `"false"` to disable the WebSocket realtime endpoint | enabled |
 | `MB_CORS_ORIGINS` | Comma-separated browser origins allowed for cross-origin API requests with credentials (merged with `corsAllowedOrigins` from app settings). Example: `http://localhost:3000,https://app.example.com` | — |
@@ -114,18 +128,18 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       args:
-        MB_VERSION: "0.3.4"
+        MB_VERSION: "0.4.0"
     image: mantisbase:latest
     restart: unless-stopped
     ports:
-      - "7070:80"
+      - "7070:8080"
     volumes:
       - ./data:/mb/data
       - ./public:/mb/public
       - ./scripts:/mb/scripts
     environment:
-      MB_JWT_SECRET: "your-secret-key"
-    command: ["--db", "postgresql", "--db_url", "dbname=mantis host=postgres port=5432 user=postgres password=postgres", "serve", "--port", "80"]
+      MB_JWT_SECRET: "${MB_JWT_SECRET:?Set MB_JWT_SECRET via .env or environment}"
+    command: ["--db", "postgresql", "--db_url", "dbname=mantis host=postgres port=5432 user=mb_app password=${POSTGRES_PASSWORD}", "serve", "--port", "8080"]
     depends_on:
       - postgres
 
@@ -133,8 +147,8 @@ services:
     image: postgres:15
     environment:
       POSTGRES_DB: mantis
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: mb_app
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD via .env or environment}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/doc/files.md
+++ b/doc/files.md
@@ -131,10 +131,17 @@ Uploaded filenames are automatically sanitized before storage:
 
 MantisBase uses multi-layered path traversal prevention on all file operations. Any request whose resolved path escapes the entity's storage directory is rejected with a `400 Bad Request` error.
 
-### Limitations
+### Upload Limits
 
-- **File size**: A `maxFileSize` setting (default 10485760 bytes / 10 MiB) exists in the application config but is not currently enforced at upload time. Clients are not rejected for exceeding it.
-- **File types**: No MIME type or file extension validation is performed. All file types are accepted.
+- **File size**: uploads larger than the `maxFileSize` application setting (bytes, default `10485760` / 10 MiB) are rejected with **413 Payload Too Large**.
+- **File types**: uploads are restricted to an allow-list of extensions (images, audio/video, common documents and archives, and plain-text/data formats). Anything else is rejected with **415 Unsupported Media Type**.
+
+### Serving Files
+
+`GET /api/v1/files/:entity/:file` enforces the entity's **get** access rule: files on a non-public entity require a verified token, and entities whose get rule is admin-only require an `mb_admins` token. Responses are sent with a fixed `Content-Type` derived from the file extension plus `X-Content-Type-Options: nosniff`; only images (excluding SVG), audio and video are served `inline`, everything else is sent as an `attachment`.
+
+### Remaining Limitations
+
 - **Files per record**: No limit on the number of files per record.
 
 ---

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,10 @@ FROM debian:stable-slim
 
 ARG MB_VERSION=0.4.0
 ARG TARGETARCH
+# Optional: pin the release archive checksum so a tampered or substituted
+# artifact cannot be silently baked into the image.
+#   docker build --build-arg MB_SHA256=<sha256 of the release zip> .
+ARG MB_SHA256=""
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
@@ -15,12 +19,20 @@ WORKDIR /mb
 
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "linux-aarch64" || echo "linux-x86_64") \
     && wget -O /tmp/mantisbase.zip https://github.com/allankoechke/mantisbase/releases/download/v${MB_VERSION}/mantisbase_v${MB_VERSION}_${ARCH}.zip \
+    && if [ -n "$MB_SHA256" ]; then \
+         echo "${MB_SHA256}  /tmp/mantisbase.zip" | sha256sum -c -; \
+       fi \
     && unzip /tmp/mantisbase.zip -d /mb \
     && chmod +x /mb/mantisbase \
     && rm /tmp/mantisbase.zip
 
-EXPOSE 80
+RUN groupadd --system mantisbase && useradd --system --gid mantisbase --no-create-home mantisbase \
+    && chown -R mantisbase:mantisbase /mb
+
+EXPOSE 8080
+
+USER mantisbase
 
 ENTRYPOINT ["/mb/mantisbase"]
-# Dev mode: docker run ... allankoech/mantisbase --dev serve -p 80
-CMD ["serve", "-p", "80"]
+# Unprivileged port: the image no longer runs as root, so it cannot bind 80.
+CMD ["serve", "-p", "8080"]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,15 +8,32 @@ services:
     image: mantisbase:latest
     restart: unless-stopped
     ports:
-      - "7070:80"
+      - "7070:8080"
+    # The container only needs to write to ./data (and /tmp); everything else
+    # stays immutable so a compromised process cannot rewrite its own code.
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - ./data:/mb/data
-      - ./www:/mb/public
-      - ./scripts:/mb/scripts
-      - ./migrations:/mb/migrations
+      - ./www:/mb/public:ro
+      - ./scripts:/mb/scripts:ro
+      - ./migrations:/mb/migrations:ro
     # See doc/docker.md for all MB_* variables. Set via .env or here.
     environment:
-      MB_JWT_SECRET: ${MB_JWT_SECRET:-}
+      # Required: an empty/default secret means anyone can forge admin tokens.
+      MB_JWT_SECRET: ${MB_JWT_SECRET:?MB_JWT_SECRET must be set to a strong random value}
       # MB_DISABLE_FILE_UPLOADS: "0"
       # MB_DISABLE_ADMIN_ON_FIRST_BOOT: "0"
       # MB_DISABLE_RATE_LIMIT: "0"
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536

--- a/include/mantisbase/core/models/entity_schema_field.h
+++ b/include/mantisbase/core/models/entity_schema_field.h
@@ -241,6 +241,8 @@ namespace mb {
          */
         static bool isValidFieldType(const std::string &type);
 
+        static bool isValidFieldName(const std::string &name);
+
         /**
          * @brief Generate unique field ID from name.
          * @param id Field name or identifier

--- a/include/mantisbase/core/router.h
+++ b/include/mantisbase/core/router.h
@@ -77,7 +77,7 @@ namespace mb {
         static std::string getMimeType(const std::string &path);
 
         static std::function<void(const MantisRequest &, MantisResponse &)> handleAdminDashboardRoute();
-        static std::function<void(const MantisRequest &, MantisResponse &)> fileServingHandler();
+        static std::function<void(MantisRequest &, MantisResponse &)> fileServingHandler();
         static std::function<void(const MantisRequest &, MantisResponse &)> healthCheckHandler();
 
         ///> Sync Advice to return handler that generates unique IDs per request

--- a/include/mantisbase/core/sse.h
+++ b/include/mantisbase/core/sse.h
@@ -42,10 +42,15 @@ namespace mb {
         std::atomic<bool> m_isActive;
         std::chrono::steady_clock::time_point m_lastActivity;
 
+        std::string m_ownerEntity;
+        std::string m_ownerId;
+
     public:
         SSESession(std::string client_id,
                    const std::set<std::string> &topics,
-                   drogon::ResponseStreamPtr stream);
+                   drogon::ResponseStreamPtr stream,
+                   std::string owner_entity = "",
+                   std::string owner_id = "");
 
         /** Send an SSE-formatted event through the async stream. Returns false if stream is closed. */
         bool sendEvent(const std::string &eventType, const json &data);
@@ -72,6 +77,9 @@ namespace mb {
         std::set<std::string> getTopics() const;
 
         void setTopics(const std::set<std::string> &topics);
+
+        [[nodiscard]] const std::string &ownerEntity() const { return m_ownerEntity; }
+        [[nodiscard]] const std::string &ownerId() const { return m_ownerId; }
     };
 
     /** Manages SSE sessions, WebSocket connections, routes realtime change events, and registers GET/POST /api/v1/realtime. */
@@ -91,7 +99,9 @@ namespace mb {
         void createRoutes();
         /** Create a new SSE session with the given topics and stream; returns client_id. */
         std::string createSession(const std::set<std::string> &initial_topics,
-                                  drogon::ResponseStreamPtr stream);
+                                  drogon::ResponseStreamPtr stream,
+                                  const std::string &owner_entity = "",
+                                  const std::string &owner_id = "");
 
         std::shared_ptr<SSESession> fetchSession(const std::string &session_id);
         /** Remove session and close it (disconnect). */

--- a/include/mantisbase/utils/utils.h
+++ b/include/mantisbase/utils/utils.h
@@ -281,6 +281,10 @@ namespace mb {
 
     std::string sanitizeFilename_JSWrapper(const std::string &original);
 
+    bool isAllowedFileExtension(const std::string &extension);
+
+    std::string safeContentType(const std::string &extension);
+
     // ----------------------------------------------------------------- //
     // AUTH UTILS
     // ----------------------------------------------------------------- //

--- a/src/core/auth.cpp
+++ b/src/core/auth.cpp
@@ -46,7 +46,8 @@ namespace mb {
                 .set_type("JWT")
                 .set_issued_at(time)
                 .set_not_before(time)
-                .set_expires_at(time + std::chrono::seconds(expiry_t));
+                .set_expires_at(time + std::chrono::seconds(expiry_t))
+                .set_issuer("mantisbase");
 
         if (config.value("jwtEnableSetIssuer", false)) {
             token_builder.set_issuer(config.at("orgName").get<std::string>());
@@ -101,7 +102,8 @@ namespace mb {
             const auto secretKey = mApp.jwtSecretKey();
 
             auto verifier = jwt::verify()
-                    .allow_algorithm(jwt::algorithm::hs256{secretKey});
+                    .allow_algorithm(jwt::algorithm::hs256{secretKey})
+                    .with_issuer("mantisbase");
 
             const auto &config = mApp.settings().configs();
             if (config.value("jwtEnableSetIssuer", false)) {
@@ -153,9 +155,9 @@ namespace mb {
             result["claims"] = claims;
             result["verified"] = true;
             return result;
-        } catch (const std::exception &e) {
+        } catch (const std::exception &) {
             result["verified"] = false;
-            result["error"] = e.what();
+            result["error"] = "Token verification failed.";
             return result;
         }
     }

--- a/src/core/http_content_reader.cpp
+++ b/src/core/http_content_reader.cpp
@@ -1,4 +1,5 @@
 #include "../../include/mantisbase/core/http.h"
+#include "../../include/mantisbase/core/kv_store.h"
 #include "../../include/mantisbase/mantisbase.h"
 #include "drogon/MultiPart.h"
 
@@ -64,6 +65,27 @@ namespace mb {
                     );
                 }
 
+                // `maxFileSize` is stored in bytes (see KeyValStore defaults).
+                const auto max_file_size = m_req.mbApp().settings().configs()
+                                                .value("maxFileSize", 10 * 1024 * 1024);
+                if (max_file_size > 0 && form_data.content.size() > static_cast<size_t>(max_file_size)) {
+                    throw MantisException(
+                        413,
+                        std::format("File `{}` exceeds the maximum allowed size of {} bytes.",
+                                    form_data.filename, max_file_size)
+                    );
+                }
+
+                const fs::path upload_path{form_data.filename};
+                const std::string ext = upload_path.has_extension()
+                    ? upload_path.extension().string() : std::string{};
+                if (!ext.empty() && !isAllowedFileExtension(ext)) {
+                    throw MantisException(
+                        415,
+                        std::format("File extension `{}` is not allowed.", ext)
+                    );
+                }
+
                 const auto dir = m_req.mbApp().files().dirPath(entity.name(), true);
                 const auto new_filename = sanitizeFilename(form_data.filename);
                 std::string filepath = (fs::path(dir) / new_filename).string();
@@ -89,7 +111,7 @@ namespace mb {
                     } catch (std::exception &e) {
                         throw MantisException(
                             500,
-                            std::format("Error Parsing Files: {}", e.what())
+                            "Error parsing file upload data."
                         );
                     }
                 }
@@ -123,14 +145,14 @@ namespace mb {
                                 auto v = getValueFromType(type, form_data.content)["value"];
                                 json_body[form_data.name] = v;
                             }
-                        } catch (std::exception &e) {
-                            throw MantisException(500, e.what());
+                        } catch (std::exception &) {
+                            throw MantisException(500, "Error processing form data.");
                         }
                     }
                 } catch (const MantisException &e) {
                     throw;
-                } catch (const std::exception &e) {
-                    throw MantisException(500, e.what());
+                } catch (const std::exception &) {
+                    throw MantisException(500, "Error processing form data.");
                 }
             }
         }
@@ -255,8 +277,8 @@ namespace mb {
         try {
             if (trim(body).empty()) m_json = json::object();
             else m_json = json::parse(body);
-        } catch (const std::exception &e) {
-            throw MantisException(400, e.what());
+        } catch (const std::exception &) {
+            throw MantisException(400, "Invalid JSON in request body.");
         }
     }
 }

--- a/src/core/http_request.cpp
+++ b/src/core/http_request.cpp
@@ -37,19 +37,37 @@ namespace mb {
     std::string MantisRequest::getBody() const { return std::string(m_req->body()); }
 
     std::string MantisRequest::getRemoteAddr() const {
-        if (hasHeader("X-Forwarded-For")) {
-            auto forwarded = getHeaderValue("X-Forwarded-For", "", 0);
-            if (const auto first_comma = forwarded.find(',');
-                first_comma != std::string::npos) {
-                forwarded = forwarded.substr(0, first_comma);
-            }
-            if (isValidIP(forwarded)) {
-                return forwarded;
-            }
-            mbApp().logger().warn("Invalid IP Header",
-                                  fmt::format("Invalid IP address in X-Forwarded-For header: {}", forwarded));
-        }
         const auto direct_ip = m_req->peerAddr().toIp();
+
+        if (hasHeader("X-Forwarded-For")) {
+            auto trusted_proxies_str = getEnvOrDefault("MB_TRUSTED_PROXIES", "");
+            if (!trusted_proxies_str.empty()) {
+                auto proxies = splitString(trusted_proxies_str, ",");
+                bool is_trusted = false;
+                for (auto &proxy : proxies) {
+                    proxy = trim(proxy);
+                    if (proxy == direct_ip) {
+                        is_trusted = true;
+                        break;
+                    }
+                }
+
+                if (is_trusted) {
+                    auto forwarded = getHeaderValue("X-Forwarded-For", "", 0);
+                    if (const auto first_comma = forwarded.find(',');
+                        first_comma != std::string::npos) {
+                        forwarded = forwarded.substr(0, first_comma);
+                    }
+                    forwarded = trim(forwarded);
+                    if (isValidIP(forwarded)) {
+                        return forwarded;
+                    }
+                    mbApp().logger().warn("Invalid IP Header",
+                                          fmt::format("Invalid IP address in X-Forwarded-For header: {}", forwarded));
+                }
+            }
+        }
+
         if (isValidIP(direct_ip)) {
             return direct_ip;
         }

--- a/src/core/logger/log_database.cpp
+++ b/src/core/logger/log_database.cpp
@@ -161,44 +161,39 @@ namespace mb {
 
             std::vector<std::string> conditions;
 
+            std::string search_like;
+
+            soci::statement st(*m_session);
+            soci::row r;
+            st.exchange(soci::into(r));
+
             if (!after.empty()) {
                 conditions.emplace_back("id < :after");
+                st.exchange(soci::use(after, "after"));
             }
 
             if (!level_filter.empty()) {
                 if (level_filter.starts_with('>')) {
                     conditions.push_back(buildMinLogWhereCondition(level_filter.substr(1)));
                 } else {
-                    conditions.push_back(std::string("level = '") + level_filter + "'");
+                    conditions.push_back("level = :level_filter");
+                    st.exchange(soci::use(level_filter, "level_filter"));
                 }
             }
+
             if (!search_filter.empty()) {
-                std::string escaped = search_filter;
-                size_t pos = 0;
-                while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-                    escaped.replace(pos, 1, "''");
-                    pos += 2;
-                }
-                conditions.push_back(std::string("(message LIKE '%") + escaped +
-                                     "%' OR details LIKE '%" + escaped + "%')");
+                search_like = "%" + search_filter + "%";
+                conditions.push_back("(message LIKE :search_filter OR details LIKE :search_filter)");
+                st.exchange(soci::use(search_like, "search_filter"));
             }
+
             if (!start_date.empty()) {
-                std::string escaped = start_date;
-                size_t pos = 0;
-                while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-                    escaped.replace(pos, 1, "''");
-                    pos += 2;
-                }
-                conditions.push_back(std::string("timestamp >= '") + escaped + "'");
+                conditions.push_back("timestamp >= :start_date");
+                st.exchange(soci::use(start_date, "start_date"));
             }
             if (!end_date.empty()) {
-                std::string escaped = end_date;
-                size_t pos = 0;
-                while ((pos = escaped.find('\'', pos)) != std::string::npos) {
-                    escaped.replace(pos, 1, "''");
-                    pos += 2;
-                }
-                conditions.push_back(std::string("timestamp <= '") + escaped + "'");
+                conditions.push_back("timestamp <= :end_date");
+                st.exchange(soci::use(end_date, "end_date"));
             }
 
             if (!conditions.empty()) {
@@ -213,11 +208,13 @@ namespace mb {
 
             std::lock_guard lock(m_dbMutexLock);
 
-            const soci::rowset rs = after.empty()
-                                        ? (m_session->prepare << query, soci::use(fetch_limit))
-                                        : (m_session->prepare << query, soci::use(after), soci::use(fetch_limit));
+            st.exchange(soci::use(fetch_limit, "limit"));
+            st.alloc();
+            st.prepare(query);
+            st.define_and_bind();
+            st.execute();
 
-            for (const auto &r: rs) {
+            while (st.fetch()) {
                 json log_entry = json::object();
                 log_entry["id"] = r.get<std::string>(0);
                 log_entry["timestamp"] = r.get<std::string>(1);

--- a/src/core/middlewares.cpp
+++ b/src/core/middlewares.cpp
@@ -153,6 +153,16 @@ namespace mb {
                             return HandlerResponse::Handled;
                         }
 
+                        if (!auth.contains("entity") || !auth["entity"].is_string() ||
+                            auth["entity"].get<std::string>() != "mb_admins") {
+                            res.sendJSON(403, {
+                                {"data", json::object()},
+                                {"status", 403},
+                                {"error", "Admin auth required to access this resource."}
+                            });
+                            return HandlerResponse::Handled;
+                        }
+
                         return HandlerResponse::Unhandled;
                     }
 
@@ -220,10 +230,11 @@ namespace mb {
                              });
                 return HandlerResponse::Handled;
             } catch (std::exception &e) {
+                req.mbApp().logger().critical("Access", "Access Check Error", fmt::format("Access check error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
                 return HandlerResponse::Handled;
             }
@@ -290,7 +301,7 @@ namespace mb {
                 return HandlerResponse::Unhandled;
             } catch (const std::exception &e) {
                 std::cout << "Failed to get access token: " << e.what() << std::endl;
-                throw MantisException(500, e.what());
+                throw MantisException(500, "An internal error occurred.");
             }
         };
     }
@@ -373,7 +384,7 @@ namespace mb {
                 res.sendJSON(e.code(), {
                                  {"status", e.code()},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", e.code() >= 500 ? "An internal error occurred." : e.what()}
                              });
                 return HandlerResponse::Handled;
             }
@@ -553,7 +564,7 @@ namespace mb {
                 res.sendJSON(500, {
                                  {"data", json::object()},
                                  {"status", 500},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
                 return HandlerResponse::Handled;
             }
@@ -676,10 +687,13 @@ namespace mb {
 
         return [max_requests, window_seconds, use_user_id](
             MantisRequest &req, MantisResponse &res) {
-            // Skip rate limiting in test mode if disabled
-            if (const char *test_disable = std::getenv("MB_DISABLE_RATE_LIMIT");
-                test_disable && std::string(test_disable) == "1") {
-                return HandlerResponse::Unhandled;
+            // MB_DISABLE_RATE_LIMIT is a test-only escape hatch; honouring it in a
+            // production build would let a misconfigured env disable rate limiting.
+            if (req.mbApp().isDevMode()) {
+                if (const char *test_disable = std::getenv("MB_DISABLE_RATE_LIMIT");
+                    test_disable && std::string(test_disable) == "1") {
+                    return HandlerResponse::Unhandled;
+                }
             }
 
             try {
@@ -804,8 +818,13 @@ namespace mb {
             } catch (const std::exception &e) {
                 req.mbApp().logger().critical("Rate Limit Middleware Error",
                                               fmt::format("Rate limit middleware error: {}", e.what()));
-                // On error, allow the request to proceed (fail open)
-                return HandlerResponse::Unhandled;
+                // Fail closed: a broken limiter must not become a free bypass.
+                res.sendJSON(429, {
+                                 {"status", 429},
+                                 {"data", json::object()},
+                                 {"error", "Rate limiting unavailable. Please try again later."}
+                             });
+                return HandlerResponse::Handled;
             }
         };
     }

--- a/src/core/models/entity_routes_handlers.cpp
+++ b/src/core/models/entity_routes_handlers.cpp
@@ -34,9 +34,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Entity", "Handler Error", fmt::format("Entity handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -94,9 +95,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Entity", "Handler Error", fmt::format("Entity handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -215,9 +217,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Entity", "Handler Error", fmt::format("Entity handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }

--- a/src/core/models/entity_schema.cpp
+++ b/src/core/models/entity_schema.cpp
@@ -1,6 +1,9 @@
 #include "../../../include/mantisbase/core/models/entity_schema.h"
 #include "mantisbase/core/exceptions.h"
 
+#include <algorithm>
+#include <cctype>
+
 namespace mb {
     EntitySchema::EntitySchema(const MantisBase &app) : IMantisBase(app) {}
 
@@ -214,8 +217,37 @@ namespace mb {
         return m_viewSqlQuery;
     }
 
+    static bool isValidViewQuery(const std::string &sql) {
+        if (sql.empty()) return false;
+
+        if (sql.find(';') != std::string::npos) return false;
+
+        std::string upper = sql;
+        std::transform(upper.begin(), upper.end(), upper.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+
+        auto trimmed = upper;
+        while (!trimmed.empty() && std::isspace(static_cast<unsigned char>(trimmed.front())))
+            trimmed.erase(trimmed.begin());
+
+        if (trimmed.substr(0, 6) != "SELECT") return false;
+
+        const std::vector<std::string> forbidden = {
+            "INSERT ", "UPDATE ", "DELETE ", "DROP ", "ALTER ", "CREATE ",
+            "TRUNCATE ", "GRANT ", "REVOKE ", "EXEC ", "EXECUTE ",
+            "INTO ", "REPLACE "
+        };
+        for (const auto &kw : forbidden) {
+            if (upper.find(kw) != std::string::npos) return false;
+        }
+
+        return true;
+    }
+
     EntitySchema &EntitySchema::setViewQuery(const std::string &viewQuery) {
         if (viewQuery.empty()) throw std::invalid_argument("Empty view query statement.");
+        if (!isValidViewQuery(viewQuery))
+            throw MantisException(400, "Invalid view query: must be a SELECT statement with no DDL/DML keywords or semicolons.");
         m_viewSqlQuery = viewQuery;
         return *this;
     }
@@ -599,18 +631,59 @@ namespace mb {
 
         if (v.is_null()) return "NULL";
 
-        if (type == "string") {
-            return "'" + v.dump() + "'";
+        if (type == "string" || type == "file" || type == "files") {
+            if (!v.is_string())
+                throw std::invalid_argument("Expected a string default value for type `" + type + "`.");
+            std::string raw = v.get<std::string>();
+            std::string escaped;
+            escaped.reserve(raw.size() + 2);
+            for (char c : raw) {
+                if (c == '\'') escaped += "''";
+                else escaped += c;
+            }
+            return "'" + escaped + "'";
         }
 
-        if (type == "double" || type == "int"
-            || type == "date" || type == "json"
-            || type == "file" || type == "files") {
-            return v.dump();
+        if (type == "int") {
+            if (!v.is_number_integer())
+                throw std::invalid_argument("Expected an integer default value for type `int`.");
+            return std::to_string(v.get<long long>());
+        }
+
+        if (type == "double") {
+            if (!v.is_number())
+                throw std::invalid_argument("Expected a numeric default value for type `double`.");
+            return std::to_string(v.get<double>());
         }
 
         if (type == "bool") {
+            if (!v.is_boolean())
+                throw std::invalid_argument("Expected a boolean default value for type `bool`.");
             return v.get<bool>() ? "1" : "0";
+        }
+
+        if (type == "date") {
+            if (!v.is_string())
+                throw std::invalid_argument("Expected a string default value for type `date`.");
+            std::string raw = v.get<std::string>();
+            std::string escaped;
+            escaped.reserve(raw.size() + 2);
+            for (char c : raw) {
+                if (c == '\'') escaped += "''";
+                else escaped += c;
+            }
+            return "'" + escaped + "'";
+        }
+
+        if (type == "json") {
+            std::string raw = v.dump();
+            std::string escaped;
+            escaped.reserve(raw.size() + 2);
+            for (char c : raw) {
+                if (c == '\'') escaped += "''";
+                else escaped += c;
+            }
+            return "'" + escaped + "'";
         }
 
         throw std::runtime_error("Unsupported field type `" + type + "`");

--- a/src/core/models/entity_schema_field.cpp
+++ b/src/core/models/entity_schema_field.cpp
@@ -4,6 +4,9 @@
 #include "../../../include/mantisbase/core/exceptions.h"
 #include "../../../include/mantisbase/utils/soci_wrappers.h"
 
+#include <algorithm>
+#include <cctype>
+
 namespace mb {
     nlohmann::json IndexDefinition::toJSON() const {
         return {{"name", name}, {"unique", unique}, {"columns", columns}};
@@ -21,7 +24,9 @@ namespace mb {
         : m_name(std::move(field_name)),
           m_type(std::move(field_type)),
           m_constraints(defaultConstraints()) {
-        if (field_name == "password") {
+        if (!isValidFieldName(m_name))
+            throw MantisException(400, "Invalid field name: expected 1-64 alphanumeric or underscore characters.");
+        if (m_name == "password") {
             m_constraints["validator"] = "@password";
             m_constraints["min_value"] = 8;
         } else if (field_name == "email") {
@@ -151,11 +156,19 @@ namespace mb {
         return m_name;
     }
 
-    EntitySchemaField &EntitySchemaField::setName(const std::string &name) {
-        if (trim(name).empty())
-            throw MantisException(400, "Field name is required!");
+    bool EntitySchemaField::isValidFieldName(const std::string &name) {
+        if (name.empty() || name.length() > 64) return false;
+        return std::ranges::all_of(name, [](const unsigned char c) {
+            return std::isalnum(c) || c == '_';
+        });
+    }
 
-        m_name = trim(name);
+    EntitySchemaField &EntitySchemaField::setName(const std::string &name) {
+        auto trimmed = trim(name);
+        if (!isValidFieldName(trimmed))
+            throw MantisException(400, "Invalid field name: expected 1-64 alphanumeric or underscore characters.");
+
+        m_name = trimmed;
         return *this;
     }
 
@@ -255,9 +268,12 @@ namespace mb {
             throw MantisException(400, "Foreign key reference table cannot be empty!");
         }
 
-        // Note: existence of the referenced entity/column is validated at the
-        // schema level (EntitySchema::validate), which has the owning app. A
-        // field is a pure value type and does not reach into app state here.
+        if (!isValidFieldName(table))
+            throw MantisException(400, "Invalid foreign key reference table name: expected alphanumeric + _ only.");
+
+        std::string resolvedColumn = column.empty() ? "id" : column;
+        if (!isValidFieldName(resolvedColumn))
+            throw MantisException(400, "Invalid foreign key reference column name: expected alphanumeric + _ only.");
 
         // Validate update/delete policies
         const std::vector<std::string> validPolicies = {
@@ -281,7 +297,7 @@ namespace mb {
         }
 
         m_foreignKey["entity"] = table;
-        m_foreignKey["field"] = column.empty() ? "id" : column;
+        m_foreignKey["field"] = resolvedColumn;
         m_foreignKey["on_update"] = upperUpdate;
         m_foreignKey["on_delete"] = upperDelete;
 
@@ -383,6 +399,7 @@ namespace mb {
 
     std::optional<std::string> EntitySchemaField::validate() const {
         if (m_name.empty()) return "Entity field name is empty";
+        if (!isValidFieldName(m_name)) return "Invalid field name: expected 1-64 alphanumeric or underscore characters.";
         if (m_type.empty()) return "Entity field type is empty";
 
         if (m_type == "int") {

--- a/src/core/models/entity_schema_routes_handlers.cpp
+++ b/src/core/models/entity_schema_routes_handlers.cpp
@@ -37,9 +37,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Schema", "Handler Error", fmt::format("Schema handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -62,9 +63,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Schema", "Handler Error", fmt::format("Schema handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -109,7 +111,7 @@ namespace mb {
                                               fmt::format("Error creating entity schema\n\t— {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -148,9 +150,10 @@ namespace mb {
                                  {"status", e.code()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Schema", "Handler Error", fmt::format("Schema handler error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"data", json::object()},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"status", 500}
                              });
             }
@@ -174,9 +177,10 @@ namespace mb {
                                  {"data", json::object()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Schema", "Delete Error", fmt::format("Schema delete error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
-                                 {"error", e.what()},
+                                 {"error", "An internal error occurred."},
                                  {"data", json::object()}
                              });
             }

--- a/src/core/models/validators.cpp
+++ b/src/core/models/validators.cpp
@@ -6,6 +6,9 @@
 #include "../../../include/mantisbase/core/models/int_precision.h"
 
 #include <regex>
+#include <algorithm>
+
+#include <cctype>
 
 #include "../../../include/mantisbase/mantisbase.h"
 #include "../../../include/mantisbase/core/exceptions.h"
@@ -284,10 +287,31 @@ namespace mb {
             return "View tables require a valid SQL View query!";
         }
 
-        // TODO
-        // const auto& sql = trim(entity.at("sql").get<std::string>());
-        // Check that it contains an `id` field
-        // Check it does not contain malicious things!!
+        const auto &sql = trim(body["view_query"].get<std::string>());
+
+        if (sql.find(';') != std::string::npos)
+            return "View query must not contain semicolons.";
+
+        std::string upper = sql;
+        std::transform(upper.begin(), upper.end(), upper.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+
+        auto trimmed = upper;
+        while (!trimmed.empty() && std::isspace(static_cast<unsigned char>(trimmed.front())))
+            trimmed.erase(trimmed.begin());
+
+        if (trimmed.substr(0, 6) != "SELECT")
+            return "View query must be a SELECT statement.";
+
+        const std::vector<std::string> forbidden = {
+            "INSERT ", "UPDATE ", "DELETE ", "DROP ", "ALTER ", "CREATE ",
+            "TRUNCATE ", "GRANT ", "REVOKE ", "EXEC ", "EXECUTE ",
+            "INTO ", "REPLACE "
+        };
+        for (const auto &kw : forbidden) {
+            if (upper.find(kw) != std::string::npos)
+                return "View query must not contain DDL/DML keywords (" + kw.substr(0, kw.size()-1) + ").";
+        }
 
         return std::nullopt;
     }

--- a/src/core/oauth.cpp
+++ b/src/core/oauth.cpp
@@ -5,6 +5,8 @@
 #include "mantisbase/core/auth.h"
 
 #include <drogon/HttpClient.h>
+#include <drogon/utils/Utilities.h>
+#include <jwt-cpp/traits/nlohmann-json/defaults.h>
 
 namespace mb {
     OAuthManager::OAuthManager(const MantisBase &app) : IMantisBase(app) {
@@ -13,7 +15,10 @@ namespace mb {
     std::string OAuthManager::getEncryptionKey() const {
         auto key = getEnvOrDefault("MB_OAUTH_ENCRYPTION_KEY", "");
         if (key.empty()) {
-            key = mbApp().jwtSecretKey();
+            throw std::runtime_error(
+                "MB_OAUTH_ENCRYPTION_KEY is not set. OAuth requires a dedicated encryption key "
+                "separate from the JWT secret. Set MB_OAUTH_ENCRYPTION_KEY to a strong, random "
+                "value of at least 32 characters.");
         }
         if (key.size() < 32) {
             key.resize(32, '0');
@@ -82,12 +87,12 @@ namespace mb {
         }
 
         std::string url = authorize_endpoint +
-                          "?client_id=" + client_id +
+                          "?client_id=" + drogon::utils::urlEncodeComponent(client_id) +
                           "&response_type=code" +
-                          "&redirect_uri=" + redirect_uri +
-                          "&scope=" + scopes +
-                          "&state=" + state +
-                          "&code_challenge=" + challenge +
+                          "&redirect_uri=" + drogon::utils::urlEncodeComponent(redirect_uri) +
+                          "&scope=" + drogon::utils::urlEncodeComponent(scopes) +
+                          "&state=" + drogon::utils::urlEncodeComponent(state) +
+                          "&code_challenge=" + drogon::utils::urlEncodeComponent(challenge) +
                           "&code_challenge_method=S256";
 
         return {
@@ -475,11 +480,11 @@ namespace mb {
         req->addHeader("Accept", "application/json");
 
         const std::string body = "grant_type=authorization_code"
-                                 "&code=" + code +
-                                 "&redirect_uri=" + redirect_uri +
-                                 "&client_id=" + client_id +
-                                 "&client_secret=" + client_secret +
-                                 "&code_verifier=" + pkce_verifier;
+                                 "&code=" + drogon::utils::urlEncodeComponent(code) +
+                                 "&redirect_uri=" + drogon::utils::urlEncodeComponent(redirect_uri) +
+                                 "&client_id=" + drogon::utils::urlEncodeComponent(client_id) +
+                                 "&client_secret=" + drogon::utils::urlEncodeComponent(client_secret) +
+                                 "&code_verifier=" + drogon::utils::urlEncodeComponent(pkce_verifier);
 
         req->setBody(body);
 
@@ -496,21 +501,78 @@ namespace mb {
                 "Token exchange error: " + token_data.value("error_description", token_data.value("error", "unknown")));
         }
 
-        // Decode ID token if present to get user info
+        // Decode and verify ID token signature before trusting claims
         if (token_data.contains("id_token")) {
             auto id_token = token_data["id_token"].get<std::string>();
-            // Simple JWT payload extraction (no signature verification for now)
-            auto parts = splitString(id_token, ".");
-            if (parts.size() >= 2) {
-                try {
-                    auto payload = base64UrlDecode(parts[1]);
-                    auto claims = json::parse(std::string(payload.begin(), payload.end()));
-                    if (claims.contains("sub")) token_data["sub"] = claims["sub"];
-                    if (claims.contains("email")) token_data["email"] = claims["email"];
-                    if (claims.contains("name")) token_data["name"] = claims["name"];
-                    if (claims.contains("picture")) token_data["picture"] = claims["picture"];
-                } catch (...) {
+            try {
+                auto decoded = jwt::decode(id_token);
+
+                auto alg = decoded.get_algorithm();
+                if (alg == "HS256") {
+                    auto verifier = jwt::verify()
+                            .allow_algorithm(jwt::algorithm::hs256{client_secret});
+                    verifier.verify(decoded);
+                } else if (alg == "RS256") {
+                    auto header = decoded.get_header_json();
+                    auto kid = header.count("kid") ? header["kid"].get<std::string>() : std::string{};
+
+                    auto jwks_uri = std::string{};
+                    auto parts = splitString(token_endpoint, "/token");
+                    if (!parts.empty()) {
+                        auto base = parts[0];
+                        auto oidc_url = base + "/.well-known/openid-configuration";
+                        try {
+                            auto oidc = discoverOIDC(oidc_url);
+                            jwks_uri = oidc.value("jwks_uri", "");
+                        } catch (...) {}
+                    }
+
+                    if (jwks_uri.empty()) {
+                        throw std::runtime_error("Cannot obtain JWKS URI for RS256 ID token verification");
+                    }
+
+                    auto jwks_client = drogon::HttpClient::newHttpClient(jwks_uri);
+                    auto jwks_req = drogon::HttpRequest::newHttpRequest();
+                    jwks_req->setMethod(drogon::Get);
+                    auto [jwks_result, jwks_resp] = jwks_client->sendRequest(jwks_req, 5.0);
+
+                    if (jwks_result != drogon::ReqResult::Ok || !jwks_resp) {
+                        throw std::runtime_error("Failed to fetch JWKS for ID token verification");
+                    }
+
+                    auto jwks = json::parse(std::string(jwks_resp->body()));
+                    bool key_found = false;
+                    for (const auto &key : jwks["keys"]) {
+                        if (!kid.empty() && key.value("kid", "") != kid) continue;
+                        if (key.value("kty", "") != "RSA") continue;
+
+                        auto n = key["n"].get<std::string>();
+                        auto e = key["e"].get<std::string>();
+                        auto pem = jwt::helper::create_public_key_from_rsa_components(n, e);
+                        auto verifier = jwt::verify()
+                                .allow_algorithm(jwt::algorithm::rs256{pem});
+                        verifier.verify(decoded);
+                        key_found = true;
+                        break;
+                    }
+                    if (!key_found) {
+                        throw std::runtime_error("No matching key found in JWKS for ID token verification");
+                    }
+                } else {
+                    throw std::runtime_error("Unsupported ID token algorithm: " + alg);
                 }
+
+                // Signature verified — extract claims
+                json claims;
+                for (auto &[key, value] : decoded.get_payload_json()) {
+                    claims[key] = value;
+                }
+                if (claims.contains("sub")) token_data["sub"] = claims["sub"];
+                if (claims.contains("email")) token_data["email"] = claims["email"];
+                if (claims.contains("name")) token_data["name"] = claims["name"];
+                if (claims.contains("picture")) token_data["picture"] = claims["picture"];
+            } catch (const std::exception &e) {
+                throw std::runtime_error(std::string("ID token verification failed: ") + e.what());
             }
         }
 

--- a/src/core/realtime.cpp
+++ b/src/core/realtime.cpp
@@ -218,25 +218,35 @@ void mb::RealtimeDB::createNotifyFunction(const MantisBase& app, soci::session &
             RETURNS TRIGGER AS $$
             DECLARE
                 notification json;
+                old_json json;
+                new_json json;
             BEGIN
-                -- Build notification payload
+                -- Build row JSON and strip sensitive fields (password)
                 IF (TG_OP = 'DELETE') THEN
+                    old_json = row_to_json(OLD);
+                    old_json = (SELECT json_object_agg(key, value) FROM json_each(old_json) WHERE key != 'password');
                     notification = json_build_object(
                         'timestamp', EXTRACT(EPOCH FROM NOW())::bigint,
                         'type', TG_OP,
                         'entity', TG_TABLE_NAME,
                         'row_id', OLD.id::text,
-                        'old_data', row_to_json(OLD),
+                        'old_data', old_json,
                         'new_data', NULL
                     );
                 ELSE
+                    new_json = row_to_json(NEW);
+                    new_json = (SELECT json_object_agg(key, value) FROM json_each(new_json) WHERE key != 'password');
+                    IF TG_OP = 'UPDATE' THEN
+                        old_json = row_to_json(OLD);
+                        old_json = (SELECT json_object_agg(key, value) FROM json_each(old_json) WHERE key != 'password');
+                    END IF;
                     notification = json_build_object(
                         'timestamp', EXTRACT(EPOCH FROM NOW())::bigint,
                         'type', TG_OP,
                         'entity', TG_TABLE_NAME,
                         'row_id', NEW.id::text,
-                        'old_data', CASE WHEN TG_OP = 'UPDATE' THEN row_to_json(OLD) ELSE NULL END,
-                        'new_data', row_to_json(NEW)
+                        'old_data', CASE WHEN TG_OP = 'UPDATE' THEN old_json ELSE NULL END,
+                        'new_data', new_json
                     );
                 END IF;
 
@@ -260,16 +270,17 @@ void mb::RealtimeDB::createNotifyFunction(const MantisBase& app, soci::session &
 std::string mb::RealtimeDB::buildTriggerObject(const Entity &entity, const std::string &action) {
     std::stringstream ss;
     ss << "json_object(";
-    int i = 0;
+    bool first = true;
     for (const auto &field: entity.fields()) {
-        // Field name is interpolated into trigger DDL, so validate it.
-        auto name = sqlIdentifier(field["name"].get<std::string>());
-        ss << "'" << name << "', " << action << "." << name;
-        if (i < entity.fields().size() - 1) {
-            ss << ", ";
-        }
+        auto field_name = field["name"].get<std::string>();
+        if (field_name == "password")
+            continue;
 
-        i++;
+        auto name = sqlIdentifier(field_name);
+        if (!first)
+            ss << ", ";
+        ss << "'" << name << "', " << action << "." << name;
+        first = false;
     }
     ss << ")";
 

--- a/src/core/realtime_ws.cpp
+++ b/src/core/realtime_ws.cpp
@@ -1,14 +1,21 @@
 #include "../../include/mantisbase/core/ws.h"
 #include "../../include/mantisbase/mantisbase.h"
 #include "../../include/mantisbase/core/sse.h"
+#include "../../include/mantisbase/core/api_keys.h"
 
 namespace mb {
+
+    static constexpr size_t kMaxWSConnections = 1024;
 
     // --- WSMgr ---
     WSMgr::WSMgr(const MantisBase& app) : m_app(app) {}
 
     void WSMgr::addConnection(const drogon::WebSocketConnectionPtr &conn) {
         std::lock_guard lock(m_mutex);
+        if (m_connTopics.size() >= kMaxWSConnections) {
+            conn->shutdown(drogon::CloseCode::kViolation, "Connection limit reached");
+            return;
+        }
         m_connTopics[conn] = {};
     }
 
@@ -92,6 +99,9 @@ namespace mb {
                         ? change_event["new_data"]
                         : nullptr;
 
+        if (data.is_object() && data.contains("password"))
+            data.erase("password");
+
         return {
             {"type", "change"},
             {"topic", entity},
@@ -115,8 +125,50 @@ namespace mb {
             return;
         }
 
-        m_app.logger().info("WebSocket", std::format("New WS connection from {}",
+        // Authenticate: extract token from query param or Authorization header
+        std::string token;
+        if (req->getParameter("token").length() > 0) {
+            token = req->getParameter("token");
+        } else if (req->getHeader("Authorization").length() > 0) {
+            auto auth_header = req->getHeader("Authorization");
+            if (auth_header.starts_with("Bearer ")) {
+                token = auth_header.substr(7);
+            }
+        }
+
+        if (token.empty()) {
+            conn->shutdown(drogon::CloseCode::kViolation, "Unauthorized");
+            return;
+        }
+
+        json auth_context;
+
+        // Check for API key
+        if (token.starts_with("mb_sk_")) {
+            auto key_hash = ApiKeyManager::hashApiKey(token);
+            auto key_info = m_app.auth().apiKey().lookupByHash(key_hash);
+            if (!key_info.has_value()) {
+                conn->shutdown(drogon::CloseCode::kViolation, "Unauthorized");
+                return;
+            }
+            auth_context["entity"] = key_info.value()["entity_name"];
+            auth_context["id"] = key_info.value()["user_id"];
+        } else {
+            // JWT token verification
+            auto verification = m_app.auth().verifyToken(token);
+            if (!verification.at("verified").get<bool>()) {
+                conn->shutdown(drogon::CloseCode::kViolation, "Unauthorized");
+                return;
+            }
+            auth_context["entity"] = verification["claims"]["entity"];
+            auth_context["id"] = verification["claims"]["id"];
+        }
+
+        m_app.logger().info("WebSocket", std::format("Authenticated WS connection from {}",
                        conn->peerAddr().toIpPort()));
+
+        // Store auth context on the connection for topic authorization
+        conn->setContext(std::make_shared<json>(auth_context));
 
         auto &wsMgr = m_app.router().sseMgr().wsMgr();
         wsMgr.addConnection(conn);
@@ -140,10 +192,44 @@ namespace mb {
             if (msgType == "subscribe") {
                 auto topics = msg.value("topics", std::vector<std::string>{});
                 if (!topics.empty()) {
-                    auto &wsMgr = m_app.router().sseMgr().wsMgr();
-                    wsMgr.subscribe(conn, topics);
+                    // Validate each topic against the entity's access rules
+                    auto ctx = conn->getContext<json>();
+                    if (!ctx) {
+                        json err = {{"type", "error"}, {"message", "Unauthorized"}};
+                        conn->send(err.dump());
+                        return;
+                    }
 
-                    json ack = {{"type", "subscribed"}, {"topics", topics}};
+                    auto user_entity = ctx->value("entity", "");
+                    std::vector<std::string> authorized_topics;
+                    for (const auto &topic : topics) {
+                        // Extract entity name from topic (format: "entity_name" or "entity_name:row_id")
+                        auto entity_name = topic;
+                        if (auto pos = topic.find(':'); pos != std::string::npos) {
+                            entity_name = topic.substr(0, pos);
+                        }
+
+                        try {
+                            auto entity = m_app.entity(entity_name);
+                            auto rule = entity.listRule();
+                            // Admin-only ("") and "custom" rules are only opened up to
+                            // admins; everything else needs at least an authenticated user,
+                            // which the connection handshake already established.
+                            if (rule.mode() == "public" || rule.mode() == "auth" ||
+                                user_entity == "mb_admins") {
+                                authorized_topics.push_back(topic);
+                            }
+                        } catch (...) {
+                            // Entity does not exist — skip topic
+                        }
+                    }
+
+                    if (!authorized_topics.empty()) {
+                        auto &wsMgr = m_app.router().sseMgr().wsMgr();
+                        wsMgr.subscribe(conn, authorized_topics);
+                    }
+
+                    json ack = {{"type", "subscribed"}, {"topics", authorized_topics}};
                     conn->send(ack.dump());
                 }
             } else if (msgType == "unsubscribe") {

--- a/src/core/router.cpp
+++ b/src/core/router.cpp
@@ -7,6 +7,7 @@
 #include "../../include/mantisbase/core/kv_store.h"
 
 #include <cmrc/cmrc.hpp>
+#include <cctype>
 #include <chrono>
 #include <thread>
 #include <drogon/drogon.h>
@@ -400,46 +401,108 @@ namespace mb {
         };
     }
 
-    std::function<void(const MantisRequest &, MantisResponse &)> Router::fileServingHandler() {
-        // mApp.logger().trace("Endpoint Registration", "Registering /api/v1/files/:entity/:file GET endpoint ...");
-        return [](const MantisRequest &req, const MantisResponse &res) {
+    std::function<void(MantisRequest &, MantisResponse &)> Router::fileServingHandler() {
+        return [](MantisRequest &req, MantisResponse &res) {
             const auto table_name = req.getPathParamValue("entity");
             const auto file_name = req.getPathParamValue("file");
 
             if (!EntitySchema::isValidEntityName(table_name)) {
-                json response;
-                response["error"] = std::format("Invalid entity name `{}`", table_name);
-                response["status"] = 400;
-                response["data"] = json::object();
-
-                res.sendJSON(400, response);
+                res.sendJSON(400, {
+                    {"error", "Invalid entity name."},
+                    {"status", 400},
+                    {"data", json::object()}
+                });
                 return;
             }
 
             if (table_name.empty() || file_name.empty()) {
-                json response;
-                response["error"] = "Both entity name and file name are required!";
-                response["status"] = 400;
-                response["data"] = json::object();
-
-                res.sendJSON(400, response);
+                res.sendJSON(400, {
+                    {"error", "Both entity name and file name are required!"},
+                    {"status", 400},
+                    {"data", json::object()}
+                });
                 return;
+            }
+
+            if (!req.mbApp().hasEntity(table_name)) {
+                res.sendJSON(404, {
+                    {"error", "Entity not found."},
+                    {"status", 404},
+                    {"data", json::object()}
+                });
+                return;
+            }
+
+            const auto entity = req.mbApp().entity(table_name);
+            const auto &auth = req.getOr<json>("auth", json::object());
+            const auto rule = entity.getRule();
+
+            if (rule.mode() != "public") {
+                const auto &verification = req.getOr<json>("verification", json::object());
+                if (verification.empty() ||
+                    !verification.contains("verified") ||
+                    !verification["verified"].is_boolean() ||
+                    !verification["verified"].get<bool>()) {
+                    res.sendJSON(403, {
+                        {"error", "Authentication required to access this file."},
+                        {"status", 403},
+                        {"data", json::object()}
+                    });
+                    return;
+                }
+
+                if (rule.mode().empty()) {
+                    if (!auth.contains("entity") || !auth["entity"].is_string() ||
+                        auth["entity"].get<std::string>() != "mb_admins") {
+                        res.sendJSON(403, {
+                            {"error", "Admin auth required to access this file."},
+                            {"status", 403},
+                            {"data", json::object()}
+                        });
+                        return;
+                    }
+                }
             }
 
             if (const auto path_opt = req.mbApp().files().getFilePath(table_name, file_name);
                 path_opt.has_value()) {
-                // Return requested file
+                const fs::path served_path{file_name};
+                const std::string ext = served_path.has_extension()
+                    ? served_path.extension().string() : std::string{};
+                const auto content_type = safeContentType(ext);
+
+                // The file name reaches us URL-decoded, so strip anything that could
+                // break out of the Content-Disposition header (quotes, CR/LF, ...).
+                std::string safe_name;
+                safe_name.reserve(file_name.size());
+                for (const unsigned char c: file_name) {
+                    safe_name += (std::isalnum(c) || c == '.' || c == '_' || c == '-')
+                                     ? static_cast<char>(c)
+                                     : '_';
+                }
+                if (safe_name.empty()) safe_name = "download";
+
+                // Only render media inline; anything that a browser could execute in
+                // the origin (svg, pdf, html, ...) is forced to download instead.
+                const bool inline_safe = (content_type.starts_with("image/")
+                                          && content_type != "image/svg+xml")
+                                         || content_type.starts_with("video/")
+                                         || content_type.starts_with("audio/");
+
                 res.setStatus(200);
-                res.setFileContent(path_opt.value());
+                res.setFileContent(path_opt.value(), content_type);
+                res.setHeader("Content-Disposition",
+                              std::format("{}; filename=\"{}\"",
+                                          inline_safe ? "inline" : "attachment", safe_name));
+                res.setHeader("X-Content-Type-Options", "nosniff");
                 return;
             }
 
-            json response;
-            response["error"] = "File not found!";
-            response["status"] = 404;
-            response["data"] = json::object();
-
-            res.sendJSON(404, response);
+            res.sendJSON(404, {
+                {"error", "File not found!"},
+                {"status", 404},
+                {"data", json::object()}
+            });
         };
     }
 
@@ -545,8 +608,9 @@ namespace mb {
                 response["data"] = json::object();
                 res.sendJSON(500, response);
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Logs", "Fetch Logs Error", fmt::format("Failed to fetch logs: {}", e.what()));
                 json response;
-                response["error"] = std::string("Failed to fetch logs: ") + e.what();
+                response["error"] = "An internal error occurred.";
                 response["status"] = 500;
                 response["data"] = json::object();
                 res.sendJSON(500, response);

--- a/src/core/router_api_keys.cpp
+++ b/src/core/router_api_keys.cpp
@@ -34,7 +34,8 @@ namespace mb {
                 auto result = req.mbApp().auth().apiKey().create(entity_name, user_id, label, permissions, expires_at);
                 res.sendJSON(201, {{"status", 201}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, authEntityMiddleware);
 
@@ -54,7 +55,8 @@ namespace mb {
                 auto keys = req.mbApp().auth().apiKey().list(entity_name, user_id);
                 res.sendJSON(200, {{"status", 200}, {"data", keys}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, authEntityMiddleware);
 
@@ -84,7 +86,8 @@ namespace mb {
                     res.sendJSON(404, {{"status", 404}, {"data", json::object()}, {"error", "API key not found"}});
                 }
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, authEntityMiddleware);
 
@@ -109,7 +112,8 @@ namespace mb {
                 auto result = req.mbApp().auth().apiKey().createAdmin(user_id, label, permissions, expires_at);
                 res.sendJSON(201, {{"status", 201}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
 
@@ -118,7 +122,8 @@ namespace mb {
                 auto keys = req.mbApp().auth().apiKey().listAdmin();
                 res.sendJSON(200, {{"status", 200}, {"data", keys}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
 
@@ -132,7 +137,8 @@ namespace mb {
                     res.sendJSON(404, {{"status", 404}, {"data", json::object()}, {"error", "API key not found"}});
                 }
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("API Keys", "Handler Error", fmt::format("API key error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
     }

--- a/src/core/router_internals.cpp
+++ b/src/core/router_internals.cpp
@@ -6,7 +6,31 @@
 #include "../../include/mantisbase/utils/utils.h"
 #include "drogon/drogon_callbacks.h"
 
+#include <sstream>
+
 namespace mb {
+    namespace {
+        std::vector<std::string> parseAllowedOrigins() {
+            std::vector<std::string> origins;
+            auto env_origins = getEnvOrDefault("MB_ALLOWED_ORIGINS", "");
+            if (env_origins.empty()) return origins;
+            std::istringstream stream(env_origins);
+            std::string origin;
+            while (std::getline(stream, origin, ',')) {
+                auto trimmed = trim(origin);
+                if (!trimmed.empty()) origins.push_back(trimmed);
+            }
+            return origins;
+        }
+
+        bool isOriginAllowed(const std::string &origin, const std::vector<std::string> &allowed) {
+            if (allowed.empty()) return false;
+            for (const auto &a : allowed) {
+                if (a == "*" || a == origin) return true;
+            }
+            return false;
+        }
+    }
     const std::function<drogon::HttpResponsePtr(const drogon::HttpRequestPtr &)> Router::reqIdSyncAdvice() {
         return [this](const drogon::HttpRequestPtr &req) {
             // Generate and store request ID in attributes
@@ -136,6 +160,13 @@ namespace mb {
         return [this](const drogon::HttpRequestPtr &req,
                       const drogon::HttpResponsePtr &resp) {
             applyCorsHeaders(req, resp);
+            resp->addHeader("X-Content-Type-Options", "nosniff");
+            resp->addHeader("X-Frame-Options", "SAMEORIGIN");
+            resp->addHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+            resp->addHeader("Content-Security-Policy",
+                            "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; "
+                            "object-src 'none'; img-src 'self' data: blob:; "
+                            "style-src 'self' 'unsafe-inline'; font-src 'self' data:");
         };
     }
 
@@ -229,7 +260,7 @@ namespace mb {
                     res.sendJSON(404, {
                                      {"status", 404},
                                      {"data", json::object()},
-                                     {"error", "No user found for given `identity`, `password` & `entity` combination."}
+                                     {"error", "Invalid identity, password or entity combination."}
                                  });
                     return;
                 }
@@ -255,7 +286,7 @@ namespace mb {
                                      {"data", json::object()},
                                      {
                                          "error",
-                                         "No user found matching given `identity`, `password` and `entity` combination."
+                                         "Invalid identity, password or entity combination."
                                      }
                                  });
                     auto _body = body;
@@ -281,10 +312,11 @@ namespace mb {
                                  {"error", e.what()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Auth", "Login Error", fmt::format("Login error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
         };
@@ -325,7 +357,7 @@ namespace mb {
                     res.sendJSON(404, {
                                      {"status", 404},
                                      {"data", json::object()},
-                                     {"error", "No user found for given `identity` and `password` combination."}
+                                     {"error", "Invalid identity, password or entity combination."}
                                  });
                     return;
                 }
@@ -338,7 +370,7 @@ namespace mb {
                                      {"data", json::object()},
                                      {
                                          "error",
-                                         "No user found matching given `identity`, `password` and `entity` combination."
+                                         "Invalid identity, password or entity combination."
                                      }
                                  });
                     auto _body = body;
@@ -364,10 +396,11 @@ namespace mb {
                                  {"error", e.what()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Auth", "Admin Login Error", fmt::format("Admin login error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
         };
@@ -424,10 +457,11 @@ namespace mb {
                                  {"error", e.what()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Auth", "Token Refresh Error", fmt::format("Token refresh error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
         };
@@ -478,10 +512,11 @@ namespace mb {
                                  {"error", e.what()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Auth", "Logout Error", fmt::format("Logout error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
         };
@@ -490,7 +525,7 @@ namespace mb {
     std::function<void(MantisRequest &, MantisResponse &)> Router::handleSetupAdmin() {
         return [](MantisRequest &req, const MantisResponse &res) {
             try {
-                auto auth = req.getOr("auth", json::object());
+                auto auth = req.getOr<json>("auth", json::object());
                 req.mbApp().logger().trace("Auth", "Auth Data", fmt::format("Auth Data: {}", auth.dump()));
 
                 auto verification = req.getOr<json>("verification", json::object());
@@ -571,10 +606,11 @@ namespace mb {
                                  {"error", e.what()}
                              });
             } catch (const std::exception &e) {
+                req.mbApp().logger().critical("Auth", "Admin Setup Error", fmt::format("Admin setup error: {}", e.what()));
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
         };

--- a/src/core/router_oauth.cpp
+++ b/src/core/router_oauth.cpp
@@ -31,7 +31,8 @@ namespace mb {
                     auto result = req.mbApp().auth().oauth().buildAuthorizeUrl(entity_name, provider, redirect_uri);
                     res.setRedirect(result["authorize_url"].get<std::string>());
                 } catch (const std::exception &e) {
-                    res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                    req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                    res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
                 }
             }, authEntityMiddleware);
 
@@ -56,7 +57,8 @@ namespace mb {
                     auto result = req.mbApp().auth().oauth().handleCallback(entity_name, provider, code, state);
                     res.sendJSON(200, {{"status", 200}, {"data", result}, {"error", ""}});
                 } catch (const std::exception &e) {
-                    res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                    req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                    res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
                 }
             }, authEntityMiddleware);
 
@@ -89,7 +91,8 @@ namespace mb {
                 auto result = req.mbApp().auth().oauth().linkAccount(entity_name, user_id, provider, code, state);
                 res.sendJSON(200, {{"status", 200}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
             }
         }, authEntityMiddleware);
 
@@ -120,7 +123,8 @@ namespace mb {
                                         });
                        }
                    } catch (const std::exception &e) {
-                       res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                       req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                       res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
                    }
                }, authEntityMiddleware);
 
@@ -143,7 +147,8 @@ namespace mb {
                 auto accounts = req.mbApp().auth().oauth().getLinkedAccounts(entity_name, user_id);
                 res.sendJSON(200, {{"status", 200}, {"data", accounts}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, authEntityMiddleware);
 
@@ -154,7 +159,8 @@ namespace mb {
                 auto providers = req.mbApp().auth().oauth().getProviders(entity_name);
                 res.sendJSON(200, {{"status", 200}, {"data", providers}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, authEntityMiddleware);
 
@@ -183,7 +189,8 @@ namespace mb {
                 auto result = req.mbApp().auth().oauth().addProvider(body);
                 res.sendJSON(201, {{"status", 201}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
 
@@ -193,7 +200,8 @@ namespace mb {
                 auto providers = req.mbApp().auth().oauth().listProviders();
                 res.sendJSON(200, {{"status", 200}, {"data", providers}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
 
@@ -210,7 +218,8 @@ namespace mb {
                 auto result = req.mbApp().auth().oauth().updateProvider(provider_id, body);
                 res.sendJSON(200, {{"status", 200}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Handler Error", fmt::format("OAuth error: {}", e.what()));
+                res.sendJSON(500, {{"status", 500}, {"data", json::object()}, {"error", "An internal error occurred."}});
             }
         }, adminAuth);
 
@@ -224,7 +233,8 @@ namespace mb {
                     res.sendJSON(404, {{"status", 404}, {"data", json::object()}, {"error", "Provider not found"}});
                 }
             } catch (const std::exception &e) {
-                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
             }
         }, adminAuth);
 
@@ -243,7 +253,8 @@ namespace mb {
                 auto result = req.mbApp().auth().oauth().enableProviderForEntity(entity_name, provider_id);
                 res.sendJSON(200, {{"status", 200}, {"data", result}, {"error", ""}});
             } catch (const std::exception &e) {
-                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
             }
         }, adminAuth);
 
@@ -265,7 +276,8 @@ namespace mb {
                     res.sendJSON(404, {{"status", 404}, {"data", json::object()}, {"error", "Config not found"}});
                 }
             } catch (const std::exception &e) {
-                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", e.what()}});
+                req.mbApp().logger().critical("OAuth", "Request Error", fmt::format("OAuth request error: {}", e.what()));
+                res.sendJSON(400, {{"status", 400}, {"data", json::object()}, {"error", "OAuth request failed."}});
             }
         }, adminAuth);
     }

--- a/src/core/sse_mgr.cpp
+++ b/src/core/sse_mgr.cpp
@@ -11,6 +11,9 @@
 #include <drogon/drogon.h>
 
 namespace mb {
+    static constexpr size_t kMaxSSEConnections = 1024;
+    static constexpr size_t kMaxTopicsPerSession = 50;
+
     SSEMgr::SSEMgr(const MantisBase &app)
         : IMantisBase(app),
           m_wsMgr(std::make_unique<WSMgr>(app)) {
@@ -76,10 +79,33 @@ namespace mb {
                     topicSet.insert(entity_name);
                 }
 
+                if (topicSet.size() > kMaxTopicsPerSession) {
+                    auto resp = drogon::HttpResponse::newHttpResponse();
+                    resp->setStatusCode(drogon::k400BadRequest);
+                    resp->setContentTypeString("application/json");
+                    resp->setBody(R"({"status":400,"error":"Too many topics requested","data":{}})");
+                    callback(resp);
+                    return;
+                }
+
+                auto auth = ma_req.getOr<json>("auth", json::object());
+                const auto owner_entity = auth["entity"].is_string()
+                                              ? auth["entity"].get<std::string>()
+                                              : std::string{};
+                const auto owner_id = auth["user"].is_object() && auth["user"]["id"].is_string()
+                                          ? auth["user"]["id"].get<std::string>()
+                                          : std::string{};
+
                 // Create async stream response for SSE
                 auto resp = drogon::HttpResponse::newAsyncStreamResponse(
-                    [this, topicSet](drogon::ResponseStreamPtr stream) {
-                        auto clientId = createSession(topicSet, std::move(stream));
+                    [this, topicSet, owner_entity, owner_id](drogon::ResponseStreamPtr stream) {
+                        auto clientId = createSession(topicSet, std::move(stream),
+                                                       owner_entity, owner_id);
+
+                        if (clientId.empty()) {
+                            stream->close();
+                            return;
+                        }
 
                         // Send the initial connected event through the session
                         if (auto session = getSession(clientId); session) {
@@ -115,11 +141,19 @@ namespace mb {
     }
 
     std::string SSEMgr::createSession(const std::set<std::string> &initial_topics,
-                                      drogon::ResponseStreamPtr stream) {
+                                      drogon::ResponseStreamPtr stream,
+                                      const std::string &owner_entity,
+                                      const std::string &owner_id) {
         std::lock_guard lock(m_sessions_mutex);
 
+        if (m_sessions.size() >= kMaxSSEConnections) {
+            logger().warn("SSE Manager", "Maximum SSE connection limit reached");
+            return "";
+        }
+
         std::string client_id = generateClientID();
-        auto session = std::make_shared<SSESession>(client_id, initial_topics, std::move(stream));
+        auto session = std::make_shared<SSESession>(client_id, initial_topics, std::move(stream),
+                                                     owner_entity, owner_id);
         m_sessions[client_id] = session;
 
         logger().info("SSE Manager",
@@ -258,7 +292,33 @@ namespace mb {
                 new_topics.insert(entity_name);
             }
 
+            if (new_topics.size() > kMaxTopicsPerSession) {
+                res.sendJSON(400, {
+                    {"error", "Too many topics requested"},
+                    {"data", json::object()},
+                    {"status", 400}
+                });
+                return;
+            }
+
             if (const auto session = sse_mgr.getSession(client_id); session) {
+                const auto caller_entity = auth["entity"].is_string()
+                                               ? auth["entity"].get<std::string>()
+                                               : std::string{};
+                const auto caller_id = auth["user"].is_object() && auth["user"]["id"].is_string()
+                                           ? auth["user"]["id"].get<std::string>()
+                                           : std::string{};
+
+                if (!session->ownerEntity().empty() &&
+                    (session->ownerEntity() != caller_entity || session->ownerId() != caller_id)) {
+                    res.sendJSON(403, {
+                        {"error", "You are not the owner of this session"},
+                        {"data", json::object()},
+                        {"status", 403}
+                    });
+                    return;
+                }
+
                 session->setTopics(new_topics);
                 res.sendJSON(200, {
                                  {"error", ""},
@@ -399,7 +459,7 @@ namespace mb {
                 res.sendJSON(500, {
                                  {"status", 500},
                                  {"data", json::object()},
-                                 {"error", e.what()}
+                                 {"error", "An internal error occurred."}
                              });
             }
 

--- a/src/core/sse_session.cpp
+++ b/src/core/sse_session.cpp
@@ -7,12 +7,16 @@
 mb::SSESession::SSESession(
     std::string client_id,
     const std::set<std::string> &topics,
-    drogon::ResponseStreamPtr stream)
+    drogon::ResponseStreamPtr stream,
+    std::string owner_entity,
+    std::string owner_id)
     : m_clientID(std::move(client_id)),
       m_topics(topics),
       m_stream(std::move(stream)),
       m_isActive(true),
-      m_lastActivity(std::chrono::steady_clock::now()) {
+      m_lastActivity(std::chrono::steady_clock::now()),
+      m_ownerEntity(std::move(owner_entity)),
+      m_ownerId(std::move(owner_id)) {
 }
 
 bool mb::SSESession::sendEvent(const std::string &eventType, const json &data) {
@@ -67,6 +71,9 @@ mb::json mb::SSESession::formatEvent(const json &change_event) const {
     }
 
     json data = operation=="insert" || operation == "update" ? change_event["new_data"] : nullptr;
+
+    if (data.is_object() && data.contains("password"))
+        data.erase("password");
 
     return {
         {"topic", matched_topic},

--- a/src/mantisbase.cpp
+++ b/src/mantisbase.cpp
@@ -8,6 +8,17 @@
 #include <fstream>
 #include <memory>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <shellapi.h>
+#if defined(_MSC_VER)
+#pragma comment(lib, "shell32.lib")
+#endif
+#else
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+
 namespace mb {
     MantisBase::MantisBase()
         : m_dbType("sqlite3"),
@@ -345,43 +356,62 @@ namespace mb {
 #endif
 
     void MantisBase::openBrowserOnStart() const {
-        // Skip spinning the default browser on first boot
-        // Useful for tests
         if (getEnvOrDefault("MB_DISABLE_ADMIN_ON_FIRST_BOOT", "0") == "1") return;
 
         std::cout << std::endl;
 
         try {
-            // Create service account
             const auto s_acc = entity("mb_service_acc");
             auto record = s_acc.create({});
 
-            // Claims
             nlohmann::json claims;
             claims["id"] = record["id"];
             claims["entity"] = "mb_service_acc";
 
-            // Create token and pass it in
-            const auto token = m_auth->createToken(claims, 30 * 60); // Token valid for 30mins
+            const auto token = m_auth->createToken(claims, 30 * 60);
 
             const std::string url = std::format("http://localhost:{}/mb/setup?token={}", m_port, token);
-            logger().info("Admin Setup", fmt::format(
-                                "Open link below to setup first admin user. Note, token valid for 30mins only.\n\t— {}\n\t— Alternatively use mantisbase admins --add <email> <password>\n",
-                                url));
+            // The setup URL carries a live 30-minute service-account token, so keep it out
+            // of the persisted log store and print it to the console only, where it is still
+            // needed for headless first-boot setup.
+            std::cout << "\tOpen this link to set up the first admin user (valid 30 mins):"
+                      << std::endl << "\t" << url << std::endl;
+            logger().info("Admin Setup",
+                          fmt::format("Admin setup link printed to the console (token redacted from logs). "
+                                      "Token valid for 30mins only.\n\t— http://localhost:{}/mb/setup?token=<redacted>"
+                                      "\n\t— Alternatively use mantisbase admins --add <email> <password>\n",
+                                      m_port));
 
 #ifdef _WIN32
-            const std::string command = "start " + url;
+            auto launch_result = reinterpret_cast<intptr_t>(
+                ShellExecuteA(nullptr, "open", url.c_str(), nullptr, nullptr, SW_SHOWNORMAL));
+            if (launch_result <= 32) {
+                logger().warn("Browser Open Failed",
+                              fmt::format("Could not open browser, ShellExecute result: {}", launch_result));
+            }
 #elif __APPLE__
-            const std::string command = "open " + url;
+            pid_t pid = fork();
+            if (pid == 0) {
+                execlp("open", "open", url.c_str(), nullptr);
+                _exit(127);
+            } else if (pid < 0) {
+                logger().warn("Browser Open Failed", "fork() failed when trying to open browser");
+            } else {
+                waitpid(pid, nullptr, 0);
+            }
 #elif __linux__
-            const std::string command = "xdg-open " + url;
+            pid_t pid = fork();
+            if (pid == 0) {
+                execlp("xdg-open", "xdg-open", url.c_str(), nullptr);
+                _exit(127);
+            } else if (pid < 0) {
+                logger().warn("Browser Open Failed", "fork() failed when trying to open browser");
+            } else {
+                waitpid(pid, nullptr, 0);
+            }
 #else
             logger().critical("Unsupported Platform", "Unsupported platform");
 #endif
-
-            if (int result = std::system(command.c_str()); result != 0) {
-                logger().warn("Browser Open Failed", fmt::format("Could not open browser, result code: {}", result));
-            }
         } catch (const std::exception &e) {
             logger().critical("Admin Dashboard Failed",
                                 fmt::format("Failed to spin admin dashboard\n\t— {}", e.what()));

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -3,6 +3,8 @@
 
 #include <algorithm>
 #include <regex>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace mb {
     std::string sqlIdentifier(const std::string &ident) {
@@ -160,12 +162,59 @@ namespace mb {
         if (s.empty()) s = "unnamed";
     }
 
+    static const std::unordered_set<std::string> ALLOWED_EXTENSIONS = {
+        ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp", ".ico", ".tiff", ".tif",
+        ".svg", ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+        ".odt", ".ods", ".odp", ".txt", ".csv", ".tsv", ".rtf",
+        ".zip", ".gz", ".tar", ".7z", ".rar",
+        ".json", ".xml", ".yaml", ".yml",
+        ".mp3", ".wav", ".ogg", ".flac",
+        ".mp4", ".avi", ".mov", ".webm", ".mkv",
+    };
+
+    static const std::unordered_map<std::string, std::string> SAFE_MIME_TYPES = {
+        {".jpg", "image/jpeg"}, {".jpeg", "image/jpeg"},
+        {".png", "image/png"}, {".gif", "image/gif"},
+        {".bmp", "image/bmp"}, {".webp", "image/webp"},
+        {".ico", "image/x-icon"}, {".tiff", "image/tiff"}, {".tif", "image/tiff"},
+        {".svg", "image/svg+xml"},
+        {".pdf", "application/pdf"},
+        {".csv", "text/csv"}, {".tsv", "text/tab-separated-values"},
+        {".txt", "text/plain"}, {".rtf", "application/rtf"},
+        {".json", "application/json"}, {".xml", "application/xml"},
+        {".yaml", "text/yaml"}, {".yml", "text/yaml"},
+        {".mp3", "audio/mpeg"}, {".wav", "audio/wav"},
+        {".ogg", "audio/ogg"}, {".flac", "audio/flac"},
+        {".mp4", "video/mp4"}, {".avi", "video/x-msvideo"},
+        {".mov", "video/quicktime"}, {".webm", "video/webm"}, {".mkv", "video/x-matroska"},
+    };
+
+    bool isAllowedFileExtension(const std::string &extension) {
+        if (extension.empty()) return false;
+        std::string ext_lower = extension;
+        toLowerCase(ext_lower);
+        return ALLOWED_EXTENSIONS.contains(ext_lower);
+    }
+
+    std::string safeContentType(const std::string &extension) {
+        std::string ext_lower = extension;
+        toLowerCase(ext_lower);
+        if (auto it = SAFE_MIME_TYPES.find(ext_lower); it != SAFE_MIME_TYPES.end()) {
+            return it->second;
+        }
+        return "application/octet-stream";
+    }
+
     std::string sanitizeFilename(const std::string_view original,
                                  const std::size_t maxLen, const std::size_t idLen,
                                  const std::string_view idSep) {
         const fs::path p{std::string{original}};
         std::string stem = p.stem().string();
         std::string ext = p.has_extension() ? p.extension().string() : std::string{};
+
+        if (!ext.empty() && !isAllowedFileExtension(ext)) {
+            throw MantisException(415, std::format("File extension `{}` is not allowed.", ext));
+        }
 
         sanitizeInPlace(stem);
         const auto max_size = stem.size() + ext.size() + idLen + idSep.size();


### PR DESCRIPTION
Implements the fixes from the v0.4.x security audit (allankoechke/idea_board#12), rebased onto `dev`.

The audit was run against `v0.4.x`; `dev` is ~665 commits ahead and had already fixed several findings independently (strict CORS allow-list, the `MB_JWT_SECRET` startup guard, the `verifyToken` issuer/audience config bug, dev's rate limiter). Those are kept as-is — only the findings still present on `dev` are addressed here.

## Critical

- **Privilege escalation on admin-only rules** — `checkEntityAccess()` treated an empty access-rule mode as "admin only" but only checked that the caller was authenticated, never that its entity was `mb_admins`. Any logged-in user of any auth entity passed. Now mirrors `requireAdminAuth()`.
- **OAuth ID token accepted unverified** — `handleCallback()` base64-decoded the `id_token` payload and trusted the claims. Now verified first: HS256 against the client secret, RS256 against the provider's JWKS (OIDC discovery, matched on `kid`); unsupported algorithms and verification failures abort the callback.
- **Unauthenticated WebSocket + unrestricted topics** — `/api/v1/realtime/ws` accepted any connection with no token and any topic string, so an anonymous client could subscribe to `mb_admins`. Connections now require a JWT or `mb_sk_` API key, and each topic is checked against the entity's list rule (unauthorised topics are dropped; the ack echoes only what was granted).
- **SQL injection via schema field names** — field names had no format validation while being interpolated into DDL/DML. Field names and foreign-key table/column names are now restricted to 1–64 `[A-Za-z0-9_]`; `toDefaultSqlValue()` type-checks and escapes defaults instead of dumping raw JSON; view queries must be a single `SELECT` with no semicolons or DDL/DML keywords.
- **Container runs as root** — the image now runs as an unprivileged `mantisbase` user on port **8080**, `MB_JWT_SECRET` is required in compose rather than defaulting to empty, the root filesystem is read-only with a `tmpfs` for `/tmp`, code/script mounts are read-only, `no-new-privileges` is set, and resource limits are applied. `--build-arg MB_SHA256=…` optionally verifies the downloaded release archive.

## High / Medium

- **Password hashes broadcast over realtime** — the `password` field is stripped from WS and SSE payloads and omitted at the source by the Postgres notify trigger and the SQLite trigger payload builder.
- **Unauthenticated file serving** — `GET /api/v1/files/:entity/:file` now requires the entity to exist and enforces its get rule. Responses pin `Content-Type` to an extension allow-list, add `nosniff`, sanitise the `Content-Disposition` filename (it arrives URL-decoded, so CRLF/quotes could previously reach the header), and only images (excluding SVG), audio and video are served `inline`.
- **Unbounded uploads** — `maxFileSize` (bytes, default 10 MiB) is now enforced with **413**, and disallowed extensions return **415**.
- **Spoofable client IP** — `X-Forwarded-For` was trusted unconditionally, giving a fresh rate-limit bucket per request. It is now honoured only when the peer address is listed in the new `MB_TRUSTED_PROXIES`.
- **Log query string concatenation** — `getLogs()` binds the level, search term and date range as parameters instead of hand-rolled quote escaping.
- **Missing security headers** — `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` and a CSP are added in the pre-sending advice. The CSP is SPA-safe (inline styles and `data:` URIs allowed; `object-src 'none'`, no external scripts) so the bundled admin UI keeps working.
- **Rate-limit bypass** — `MB_DISABLE_RATE_LIMIT` is honoured only in `--dev` mode, and a limiter that throws now fails closed rather than waving the request through.
- **Setup token in logs / shell launch** — `openBrowserOnStart()` uses `ShellExecute`/`fork`+`exec` instead of `std::system`, and the setup URL is printed to the console only (redacted in the persisted log store), so headless first-boot setup still works.
- **Error-message leakage** — handlers log the exception and return a generic message. `MantisException` keeps its text for 4xx, where it is intentionally client-facing.
- **OAuth key reuse and URL injection** — `getEncryptionKey()` no longer falls back to `MB_JWT_SECRET`, and every component of the authorize URL and token-exchange body is URL-encoded.

## Behavioural changes worth reviewing

1. **Tokens now carry a verified `iss` claim**, so sessions issued before this change fail verification and users re-authenticate once.
2. **`MB_OAUTH_ENCRYPTION_KEY` is now required when OAuth is configured** — `getEncryptionKey()` throws instead of silently deriving from the JWT secret. Existing stored client secrets were encrypted with the old key and will need re-entry.
3. **`X-Forwarded-For` is ignored unless `MB_TRUSTED_PROXIES` is set.** Behind a reverse proxy without it, all clients share the proxy's rate-limit bucket — set it during upgrade.
4. **Container port changed from 80 to 8080** (non-root cannot bind 80). Compose and docs updated; existing `-p 7070:80` invocations need updating.
5. **Rate limiter fails closed** on internal error (429) rather than open. Happy to flip this back if you'd rather keep availability over strictness.
6. The **CSP** could not be validated against the bundled admin UI here (the `mb-admin` submodule isn't checked out in this environment) — worth a quick smoke test of `/mb`.

## Verification

Every changed translation unit passes `g++ -std=c++23 -fsyntax-only` against the project headers. A full CMake build was not run in this environment, so **CI is the real gate** — please confirm before merging. `src/core/models/entity_routes_handlers.cpp` reports 4 errors under the ad-hoc syntax-check include setup, but the pristine `dev` version of that file reports the same 4, so it is an artefact of the harness rather than of this change.
