### PR TITLE
feat: Python and JavaScript scripting support via native bindings

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,6 +7,8 @@
 - **docs.yml** — Build Doxygen docs and publish to `gh-pages`. Triggered by tag push `v*` or manually via **Run workflow** (`workflow_dispatch`).
 - **build-matrix.yml** — Reusable: matrix build (Linux x86-64 on `ubuntu-latest`, Linux aarch64 on `ubuntu-24.04-arm`, Windows x86-64), test, and on tag zip/upload artifacts. Job names show the platform (e.g. `Build (linux-aarch64)`). Library artifacts use `lib/<platform>/<mode>/<architecture>/` (e.g. `lib/linux/shared/x86-64/libmantisbase.so`). Platform binary zips include `README.md` and `LICENSE`.
 - **docker-publish.yml** — Reusable: build image from `docker/`, push to Docker Hub. Stable releases get `{version}` and `latest`; pre-releases get `{version}` and the channel tag (`alpha`, `beta`, or `rc`).
+- **bindings-node.yml** — On tag push `v*` or manual dispatch: build the Node.js N-API addon in `bindings/node` across OS × Node LTS, upload prebuilt `.node` binaries as Release assets, then `npm publish`.
+- **bindings-python.yml** — On tag push `v*` or manual dispatch: build Python wheels for `bindings/python` with `cibuildwheel` (CPython 3.9–3.13, manylinux/musllinux/macOS/Windows) plus an sdist, then publish to PyPI via trusted publishing.
 
 ## Release tag convention
 

--- a/.github/workflows/bindings-node.yml
+++ b/.github/workflows/bindings-node.yml
@@ -1,0 +1,95 @@
+name: Build & Publish Node.js Bindings
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: ['18.x', '20.x', '22.x']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        working-directory: bindings/node
+        run: npm install --ignore-scripts
+
+      - name: Build native addon
+        working-directory: bindings/node
+        run: npx cmake-js build --runtime napi
+
+      - name: Create prebuild
+        working-directory: bindings/node
+        run: npx prebuild --runtime napi --strip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload prebuild artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuild-${{ matrix.os }}-node${{ matrix.node }}
+          path: bindings/node/prebuilds/
+
+  upload-prebuilds:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Download all prebuild artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bindings/node/prebuilds/
+          merge-multiple: true
+
+      - name: Upload prebuilds to GitHub Release
+        working-directory: bindings/node
+        run: npx prebuild --upload-all $GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: upload-prebuilds
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download all prebuild artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bindings/node/prebuilds/
+          merge-multiple: true
+
+      - name: Publish to npm
+        working-directory: bindings/node
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bindings-python.yml
+++ b/.github/workflows/bindings-python.yml
@@ -1,0 +1,94 @@
+name: Build & Publish Python Wheels
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse bindings/python
+        env:
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-musllinux_i686 *-manylinux_i686 *-win32"
+          CIBW_ARCHS_LINUX: "x86_64 aarch64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_MUSLLINUX_X86_64_IMAGE: "musllinux_1_2"
+          CIBW_TEST_COMMAND: "python -c \"import mantisbase; print('ok')\""
+          CIBW_BUILD_VERBOSITY: 1
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist bindings/python --outdir sdist/
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: sdist/*.tar.gz
+
+  publish:
+    needs: [build-wheels, build-sdist]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mantisbase
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          pattern: wheels-*
+          merge-multiple: true
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 option(MB_SCRIPTING_ENABLED "Enable JS Scripting" OFF)
+option(MB_BUILD_BINDINGS "Build language bindings (Node.js, Python)" OFF)
 
 # Flag for building deps as shared/static libs
 option(MB_SHARED_DEPS "Build MantisBase as a shared library" FALSE)
@@ -130,6 +131,18 @@ if(NOT MB_SHARED_DEPS AND MB_BUILD_SHARED_LIB)
         CXX_VISIBILITY_PRESET hidden
         VISIBILITY_INLINES_HIDDEN YES
         WINDOWS_EXPORT_ALL_SYMBOLS ON
+    )
+
+    # Installed so the Node.js / Python binding builds can consume the shared
+    # library and public headers without re-building the whole project.
+    install(TARGETS mantisbase-dll
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin
+    )
+    install(DIRECTORY include/mantisbase/ DESTINATION include/mantisbase
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+        PATTERN "private-impl" EXCLUDE
     )
 endif()
 
@@ -261,4 +274,12 @@ if(TARGET mantisbase-dll)
             target_compile_definitions(mantisbase-dll PUBLIC ${_mb_defs})
         endif()
     endif()
+endif()
+
+# Language bindings (Node.js N-API, Python nanobind)
+if(MB_BUILD_BINDINGS)
+    if(NOT MB_BUILD_SHARED_LIB AND NOT MB_SHARED_DEPS)
+        message(FATAL_ERROR "MB_BUILD_BINDINGS requires MB_BUILD_SHARED_LIB=ON or MB_SHARED_DEPS=ON")
+    endif()
+    add_subdirectory(bindings)
 endif()

--- a/bindings/.gitignore
+++ b/bindings/.gitignore
@@ -1,0 +1,12 @@
+# Node.js addon build artefacts
+node_modules/
+prebuilds/
+*.node
+package-lock.json
+
+# Python extension build artefacts
+__pycache__/
+*.egg-info/
+dist/
+wheelhouse/
+_skbuild/

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Language bindings for mantisbase
+# Each subdirectory is added when its dependencies are available.
+
+add_subdirectory(node)
+add_subdirectory(python)

--- a/bindings/node/CMakeLists.txt
+++ b/bindings/node/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.22)
+project(mantisbase-node LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# When driven by cmake-js, CMAKE_JS_INC is set automatically.
+# When included from the parent CMakeLists.txt without cmake-js, skip gracefully.
+if(NOT CMAKE_JS_INC)
+    message(STATUS "[mantisbase-node] cmake-js variables not found; skipping Node.js addon.")
+    message(STATUS "  Build via: cd bindings/node && npm install")
+    return()
+endif()
+
+# Locate node-addon-api headers
+execute_process(
+    COMMAND node -p "require('node-addon-api').include"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE NODE_ADDON_API_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _napi_result
+)
+if(NOT _napi_result EQUAL 0)
+    message(FATAL_ERROR "Failed to locate node-addon-api. Run 'npm install' in ${CMAKE_CURRENT_SOURCE_DIR} first.")
+endif()
+string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
+
+# Addon shared library
+add_library(mantisbase_node SHARED
+    src/addon.cpp
+    src/app_wrap.cpp
+    src/router_wrap.cpp
+    src/request_wrap.cpp
+    src/response_wrap.cpp
+    src/db_wrap.cpp
+)
+
+target_include_directories(mantisbase_node PRIVATE
+    ${CMAKE_JS_INC}
+    ${NODE_ADDON_API_DIR}
+)
+
+# Link against mantisbase shared library
+if(TARGET mb::shared)
+    target_link_libraries(mantisbase_node PRIVATE mb::shared ${CMAKE_JS_LIB})
+else()
+    find_library(MANTISBASE_LIB mantisbase REQUIRED)
+    find_path(MANTISBASE_INCLUDE mantisbase/mantisbase.h REQUIRED)
+    target_link_libraries(mantisbase_node PRIVATE ${MANTISBASE_LIB} ${CMAKE_JS_LIB})
+    target_include_directories(mantisbase_node PRIVATE ${MANTISBASE_INCLUDE})
+endif()
+
+set_target_properties(mantisbase_node PROPERTIES
+    PREFIX ""
+    SUFFIX ".node"
+    OUTPUT_NAME "mantisbase"
+)
+
+target_compile_definitions(mantisbase_node PRIVATE
+    NAPI_VERSION=8
+    NAPI_DISABLE_CPP_EXCEPTIONS
+)

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -1,0 +1,88 @@
+# mantisbase (Node.js)
+
+Node.js bindings for [mantisbase](https://github.com/allankoechke/mantisbase), a
+C++20 single-binary backend-as-a-service. Require it like Express and drive the
+whole server from JavaScript.
+
+```bash
+npm install mantisbase
+```
+
+```js
+const { App } = require('mantisbase')
+
+const app = new App({ port: 8080, dataDir: './data' })
+
+app.router.get('/hello/:name', (req, res) => {
+    res.json(200, { message: `Hello, ${req.pathParam('name')}!` })
+})
+
+app.router.post('/items', async (req, res) => {
+    const body = req.json()
+    const rows = await app.db.query(
+        'INSERT INTO items (name) VALUES (:name) RETURNING *',
+        { name: body.name }
+    )
+    res.json(201, rows[0])
+})
+
+app.start()  // non-blocking; Drogon runs on a background thread
+```
+
+TypeScript declarations ship with the package (`index.d.ts`).
+
+## API
+
+### `new App(config)`
+
+Config keys mirror the CLI flags: `port`, `host`, `dataDir`, `dbType`, `dbUrl`,
+`publicDir`, `scriptsDir`, `migrationsDir`, `poolSize`, `dev`,
+`skipAdminSetup`. `secretKey` sets the `MB_JWT_SECRET` environment variable.
+
+- `start()` — start the HTTP server on a background thread (non-blocking).
+- `stop()` — shut the server down and join the thread.
+- `router` / `db` — the `Router` and `Database` instances.
+
+### `Router`
+
+`get(path, handler)`, `post(...)`, `patch(...)`, `delete(...)`. Handlers may be
+`async`; the response is sent once the returned Promise settles.
+
+### `MantisRequest`
+
+`pathParam(name)`, `queryParam(name)`, `header(name)`, `json()`, `body()`, and
+the read-only properties `method`, `path`, `remoteAddr`.
+
+### `MantisResponse`
+
+`json(status, data)`, `html(status, body)`, `text(status, body)`,
+`send(status, body, contentType)`, `redirect(url, status)`,
+`setHeader(name, value)`.
+
+### `Database`
+
+`query(sql, ...params)` where each param is an object of named binds. Returns a
+Promise resolving to an array of row objects keyed by column name. The query
+runs on a libuv worker thread, so the Node.js event loop is never blocked.
+
+## Threading
+
+Route handlers are dispatched from mantisbase's C++ worker threads onto the
+Node.js event loop via `napi_threadsafe_function`. The originating C++ thread
+blocks until the handler (and its Promise, if async) completes, so concurrent
+request capacity is bounded by the server's thread pool size.
+
+## Building from source
+
+```bash
+cd bindings/node
+npm install       # prebuild-install, falling back to a cmake-js build
+npx cmake-js build
+```
+
+Requires CMake >= 3.22, a C++20 compiler, and the mantisbase shared library
+(`cmake -DMB_BUILD_SHARED_LIB=ON -DMB_BUILD_BINDINGS=ON ..`).
+
+## License
+
+MIT

--- a/bindings/node/index.d.ts
+++ b/bindings/node/index.d.ts
@@ -1,0 +1,57 @@
+export interface AppConfig {
+  port?: number;
+  host?: string;
+  dataDir?: string;
+  dbType?: string;
+  dbUrl?: string;
+  /** JWT signing key. Exported as the `MB_JWT_SECRET` environment variable. */
+  secretKey?: string;
+  publicDir?: string;
+  scriptsDir?: string;
+  migrationsDir?: string;
+  poolSize?: number;
+  dev?: boolean;
+  skipAdminSetup?: boolean;
+}
+
+export type RouteHandler = (req: MantisRequest, res: MantisResponse) => void | Promise<void>;
+
+export class MantisRequest {
+  pathParam(name: string): string;
+  queryParam(name: string): string;
+  header(name: string): string;
+  json(): unknown;
+  body(): string;
+  readonly method: string;
+  readonly path: string;
+  readonly remoteAddr: string;
+}
+
+export class MantisResponse {
+  json(statusCode: number, data: unknown): void;
+  html(statusCode: number, body: string): void;
+  text(statusCode: number, body: string): void;
+  send(statusCode: number, body?: string, contentType?: string): void;
+  redirect(url: string, status?: number): void;
+  setHeader(name: string, value: string): void;
+}
+
+export class Router {
+  get(path: string, handler: RouteHandler): void;
+  post(path: string, handler: RouteHandler): void;
+  patch(path: string, handler: RouteHandler): void;
+  delete(path: string, handler: RouteHandler): void;
+}
+
+export class Database {
+  query(sql: string, ...params: Record<string, string | number | boolean | null>[]): Promise<Record<string, unknown>[]>;
+  readonly connected: boolean;
+}
+
+export class App {
+  constructor(opts?: AppConfig);
+  start(): void;
+  stop(): void;
+  readonly router: Router;
+  readonly db: Database;
+}

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,0 +1,33 @@
+const path = require('path');
+
+// `prebuild-install` (see the "install" script in package.json) downloads a
+// prebuilt binary into build/Release/ when one exists for this platform, and
+// falls back to a cmake-js compile otherwise. Either way the addon ends up in
+// one of the locations below, so loading is just a matter of finding it.
+const CANDIDATES = [
+    path.join(__dirname, 'build', 'Release', 'mantisbase.node'),
+    path.join(__dirname, 'build', 'Debug', 'mantisbase.node'),
+    path.join(__dirname, 'prebuilds', `${process.platform}-${process.arch}`, 'mantisbase.node'),
+];
+
+let binding;
+const errors = [];
+
+for (const candidate of CANDIDATES) {
+    try {
+        binding = require(candidate);
+        break;
+    } catch (err) {
+        errors.push(`  ${candidate}: ${err.message}`);
+    }
+}
+
+if (!binding) {
+    throw new Error(
+        'Failed to load the mantisbase native addon. Tried:\n' +
+        errors.join('\n') +
+        '\n\nBuild it from source with: npx cmake-js build'
+    );
+}
+
+module.exports = binding;

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "mantisbase",
+  "version": "0.1.0",
+  "description": "Node.js bindings for mantisbase — Express-style HTTP server backed by a native C++ engine",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "install": "prebuild-install -r napi || cmake-js build",
+    "build": "cmake-js build",
+    "build:debug": "cmake-js build --debug",
+    "rebuild": "cmake-js rebuild",
+    "clean": "cmake-js clean"
+  },
+  "dependencies": {
+    "node-addon-api": "^7.1.0",
+    "prebuild-install": "^7.1.2"
+  },
+  "devDependencies": {
+    "cmake-js": "^7.3.0"
+  },
+  "files": [
+    "index.js",
+    "README.md",
+    "index.d.ts",
+    "src/",
+    "CMakeLists.txt",
+    "prebuilds/"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/allankoechke/mantisbase.git",
+    "directory": "bindings/node"
+  },
+  "keywords": [
+    "mantisbase",
+    "http",
+    "server",
+    "native",
+    "napi",
+    "database"
+  ]
+}

--- a/bindings/node/src/addon.cpp
+++ b/bindings/node/src/addon.cpp
@@ -1,0 +1,17 @@
+#include <napi.h>
+#include "app_wrap.h"
+#include "router_wrap.h"
+#include "request_wrap.h"
+#include "response_wrap.h"
+#include "db_wrap.h"
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set("App", AppWrap::GetClass(env));
+    exports.Set("Router", RouterWrap::GetClass(env));
+    exports.Set("MantisRequest", RequestWrap::GetClass(env));
+    exports.Set("MantisResponse", ResponseWrap::GetClass(env));
+    exports.Set("Database", DbWrap::GetClass(env));
+    return exports;
+}
+
+NODE_API_MODULE(mantisbase, Init)

--- a/bindings/node/src/app_wrap.cpp
+++ b/bindings/node/src/app_wrap.cpp
@@ -1,0 +1,145 @@
+#include "app_wrap.h"
+#include "router_wrap.h"
+#include "db_wrap.h"
+#include <nlohmann/json.hpp>
+#include <cstdlib>
+
+using json = nlohmann::json;
+
+Napi::Function AppWrap::GetClass(Napi::Env env) {
+    return DefineClass(env, "App", {
+        InstanceMethod<&AppWrap::Start>("start"),
+        InstanceMethod<&AppWrap::Stop>("stop"),
+        InstanceAccessor<&AppWrap::GetRouter>("router"),
+        InstanceAccessor<&AppWrap::GetDb>("db"),
+    });
+}
+
+AppWrap::AppWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<AppWrap>(info) {
+
+    json config = json::object();
+    config["serve"] = json::object();
+
+    if (info.Length() > 0 && info[0].IsObject()) {
+        Napi::Object opts = info[0].As<Napi::Object>();
+
+        if (opts.Has("port") && opts.Get("port").IsNumber()) {
+            config["serve"]["port"] = opts.Get("port").As<Napi::Number>().Int32Value();
+        }
+        if (opts.Has("host") && opts.Get("host").IsString()) {
+            config["serve"]["host"] = opts.Get("host").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("dataDir") && opts.Get("dataDir").IsString()) {
+            config["data-dir"] = opts.Get("dataDir").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("dbType") && opts.Get("dbType").IsString()) {
+            config["db"] = opts.Get("dbType").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("dbUrl") && opts.Get("dbUrl").IsString()) {
+            config["db_url"] = opts.Get("dbUrl").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("publicDir") && opts.Get("publicDir").IsString()) {
+            config["public-dir"] = opts.Get("publicDir").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("scriptsDir") && opts.Get("scriptsDir").IsString()) {
+            config["scripts-dir"] = opts.Get("scriptsDir").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("migrationsDir") && opts.Get("migrationsDir").IsString()) {
+            config["migrations-dir"] = opts.Get("migrationsDir").As<Napi::String>().Utf8Value();
+        }
+        if (opts.Has("poolSize") && opts.Get("poolSize").IsNumber()) {
+            config["serve"]["pool-size"] = opts.Get("poolSize").As<Napi::Number>().Int32Value();
+        }
+        // `dev` is a presence-only flag in MantisBase::create() -- only add the
+        // key when the caller actually asked for dev mode.
+        if (opts.Has("dev") && opts.Get("dev").ToBoolean().Value()) {
+            config["dev"] = true;
+        }
+        if (opts.Has("skipAdminSetup") && opts.Get("skipAdminSetup").IsBoolean()) {
+            config["serve"]["skip-admin-setup"] = opts.Get("skipAdminSetup").As<Napi::Boolean>().Value();
+        }
+
+        // MantisBase reads the JWT signing key from the environment, so there is
+        // no CLI/config equivalent to forward it through.
+        if (opts.Has("secretKey") && opts.Get("secretKey").IsString()) {
+            const std::string secret = opts.Get("secretKey").As<Napi::String>().Utf8Value();
+#ifdef _WIN32
+            _putenv_s("MB_JWT_SECRET", secret.c_str());
+#else
+            ::setenv("MB_JWT_SECRET", secret.c_str(), 1);
+#endif
+        }
+    }
+
+    m_app = mb::MantisBase::create(config);
+    if (!m_app) {
+        Napi::Error::New(info.Env(), "Failed to create MantisBase instance")
+            .ThrowAsJavaScriptException();
+    }
+}
+
+AppWrap::~AppWrap() {
+    if (m_running.load()) {
+        m_app->close();
+        if (m_serverThread.joinable()) {
+            m_serverThread.join();
+        }
+    }
+}
+
+Napi::Value AppWrap::Start(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (m_running.load()) {
+        return env.Undefined();
+    }
+
+    m_running.store(true);
+    m_serverThread = std::thread([this]() {
+        m_app->run();
+        m_running.store(false);
+    });
+
+    return env.Undefined();
+}
+
+Napi::Value AppWrap::Stop(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (!m_running.load()) {
+        return env.Undefined();
+    }
+
+    m_app->close();
+    if (m_serverThread.joinable()) {
+        m_serverThread.join();
+    }
+    m_running.store(false);
+
+    return env.Undefined();
+}
+
+Napi::Value AppWrap::GetRouter(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (m_routerRef.IsEmpty()) {
+        Napi::Object routerObj = RouterWrap::NewInstance(env, &m_app->router());
+        m_routerRef = Napi::Persistent(routerObj);
+        m_routerRef.SuppressDestruct();
+    }
+
+    return m_routerRef.Value();
+}
+
+Napi::Value AppWrap::GetDb(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (m_dbRef.IsEmpty()) {
+        Napi::Object dbObj = DbWrap::NewInstance(env, &m_app->db());
+        m_dbRef = Napi::Persistent(dbObj);
+        m_dbRef.SuppressDestruct();
+    }
+
+    return m_dbRef.Value();
+}

--- a/bindings/node/src/app_wrap.h
+++ b/bindings/node/src/app_wrap.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <napi.h>
+#include <mantisbase/mantisbase.h>
+#include <thread>
+#include <atomic>
+
+class RouterWrap;
+class DbWrap;
+
+class AppWrap : public Napi::ObjectWrap<AppWrap> {
+public:
+    static Napi::Function GetClass(Napi::Env env);
+    AppWrap(const Napi::CallbackInfo& info);
+    ~AppWrap();
+
+    mb::MantisBase* getApp() { return m_app.get(); }
+
+private:
+    Napi::Value Start(const Napi::CallbackInfo& info);
+    Napi::Value Stop(const Napi::CallbackInfo& info);
+    Napi::Value GetRouter(const Napi::CallbackInfo& info);
+    Napi::Value GetDb(const Napi::CallbackInfo& info);
+
+    std::unique_ptr<mb::MantisBase> m_app;
+    std::thread m_serverThread;
+    std::atomic<bool> m_running{false};
+    Napi::ObjectReference m_routerRef;
+    Napi::ObjectReference m_dbRef;
+};

--- a/bindings/node/src/db_wrap.cpp
+++ b/bindings/node/src/db_wrap.cpp
@@ -1,0 +1,260 @@
+#include "db_wrap.h"
+#include <nlohmann/json.hpp>
+#include <soci/soci.h>
+
+using json = nlohmann::json;
+
+Napi::FunctionReference DbWrap::s_constructor;
+
+static Napi::Value JsonToNapi(Napi::Env env, const json& j) {
+    if (j.is_null()) return env.Null();
+    if (j.is_boolean()) return Napi::Boolean::New(env, j.get<bool>());
+    if (j.is_number_integer()) return Napi::Number::New(env, static_cast<double>(j.get<int64_t>()));
+    if (j.is_number_float()) return Napi::Number::New(env, j.get<double>());
+    if (j.is_string()) return Napi::String::New(env, j.get<std::string>());
+    if (j.is_array()) {
+        auto arr = Napi::Array::New(env, j.size());
+        for (size_t i = 0; i < j.size(); ++i) {
+            arr.Set(static_cast<uint32_t>(i), JsonToNapi(env, j[i]));
+        }
+        return arr;
+    }
+    if (j.is_object()) {
+        auto obj = Napi::Object::New(env);
+        for (auto it = j.begin(); it != j.end(); ++it) {
+            obj.Set(it.key(), JsonToNapi(env, it.value()));
+        }
+        return obj;
+    }
+    return env.Undefined();
+}
+
+static json NapiToJson(Napi::Value val) {
+    if (val.IsNull() || val.IsUndefined()) return nullptr;
+    if (val.IsBoolean()) return val.As<Napi::Boolean>().Value();
+    if (val.IsNumber()) {
+        double d = val.As<Napi::Number>().DoubleValue();
+        if (d == static_cast<int64_t>(d) && d >= -9007199254740992.0 && d <= 9007199254740992.0) {
+            return static_cast<int64_t>(d);
+        }
+        return d;
+    }
+    if (val.IsString()) return val.As<Napi::String>().Utf8Value();
+    if (val.IsArray()) {
+        auto arr = val.As<Napi::Array>();
+        json j = json::array();
+        for (uint32_t i = 0; i < arr.Length(); ++i) {
+            j.push_back(NapiToJson(arr.Get(i)));
+        }
+        return j;
+    }
+    if (val.IsObject()) {
+        auto obj = val.As<Napi::Object>();
+        json j = json::object();
+        auto names = obj.GetPropertyNames();
+        for (uint32_t i = 0; i < names.Length(); ++i) {
+            std::string key = names.Get(i).As<Napi::String>().Utf8Value();
+            j[key] = NapiToJson(obj.Get(key));
+        }
+        return j;
+    }
+    return nullptr;
+}
+
+static json SociRowToJson(const soci::row& row) {
+    json obj = json::object();
+    for (size_t i = 0; i < row.size(); ++i) {
+        const auto& props = row.get_properties(i);
+        const std::string& name = props.get_name();
+
+        if (row.get_indicator(i) == soci::i_null) {
+            obj[name] = nullptr;
+            continue;
+        }
+
+        switch (props.get_db_type()) {
+            case soci::db_string:
+            case soci::db_xml:
+                obj[name] = row.get<std::string>(i);
+                break;
+            case soci::db_double:
+                obj[name] = row.get<double>(i);
+                break;
+            case soci::db_int8:
+                obj[name] = static_cast<int64_t>(row.get<int8_t>(i));
+                break;
+            case soci::db_uint8:
+                obj[name] = static_cast<int64_t>(row.get<uint8_t>(i));
+                break;
+            case soci::db_int16:
+                obj[name] = static_cast<int64_t>(row.get<int16_t>(i));
+                break;
+            case soci::db_uint16:
+                obj[name] = static_cast<int64_t>(row.get<uint16_t>(i));
+                break;
+            case soci::db_int32:
+                obj[name] = static_cast<int64_t>(row.get<int32_t>(i));
+                break;
+            case soci::db_uint32:
+                obj[name] = static_cast<int64_t>(row.get<uint32_t>(i));
+                break;
+            case soci::db_int64:
+                obj[name] = static_cast<int64_t>(row.get<int64_t>(i));
+                break;
+            case soci::db_uint64:
+                obj[name] = static_cast<int64_t>(row.get<uint64_t>(i));
+                break;
+            case soci::db_date: {
+                std::tm t = row.get<std::tm>(i);
+                char buf[32];
+                std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &t);
+                obj[name] = std::string(buf);
+                break;
+            }
+            default:
+                obj[name] = row.get<std::string>(i);
+                break;
+        }
+    }
+    return obj;
+}
+
+class DbQueryWorker : public Napi::AsyncWorker {
+public:
+    DbQueryWorker(Napi::Env env, mb::Database* db,
+                  std::string sql, soci::values binds, bool hasBinds,
+                  Napi::Promise::Deferred deferred)
+        : Napi::AsyncWorker(env)
+        , m_db(db)
+        , m_sql(std::move(sql))
+        , m_binds(std::move(binds))
+        , m_hasBinds(hasBinds)
+        , m_deferred(deferred) {}
+
+    void Execute() override {
+        try {
+            auto session = m_db->session();
+
+            soci::row data_row;
+            soci::statement st = m_hasBinds
+                ? (session->prepare << m_sql, soci::use(m_binds), soci::into(data_row))
+                : (session->prepare << m_sql, soci::into(data_row));
+            st.execute();
+
+            m_results = json::array();
+            while (st.fetch()) {
+                m_results.push_back(SociRowToJson(data_row));
+            }
+        } catch (const std::exception& e) {
+            SetError(e.what());
+        }
+    }
+
+    void OnOK() override {
+        Napi::Env env = Env();
+        Napi::HandleScope scope(env);
+
+        if (m_results.empty()) {
+            m_deferred.Resolve(Napi::Array::New(env, 0));
+        } else {
+            m_deferred.Resolve(JsonToNapi(env, m_results));
+        }
+    }
+
+    void OnError(const Napi::Error& error) override {
+        m_deferred.Reject(error.Value());
+    }
+
+private:
+    mb::Database* m_db;
+    std::string m_sql;
+    soci::values m_binds;
+    bool m_hasBinds;
+    Napi::Promise::Deferred m_deferred;
+    json m_results;
+};
+
+Napi::Function DbWrap::GetClass(Napi::Env env) {
+    auto func = DefineClass(env, "Database", {
+        InstanceMethod<&DbWrap::Query>("query"),
+        InstanceAccessor<&DbWrap::IsConnected>("connected"),
+    });
+
+    s_constructor = Napi::Persistent(func);
+    s_constructor.SuppressDestruct();
+
+    return func;
+}
+
+DbWrap::DbWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<DbWrap>(info) {
+
+    if (info.Length() > 0 && info[0].IsExternal()) {
+        m_db = info[0].As<Napi::External<mb::Database>>().Data();
+    }
+}
+
+Napi::Object DbWrap::NewInstance(Napi::Env env, mb::Database* db) {
+    return s_constructor.New({Napi::External<mb::Database>::New(env, db)});
+}
+
+Napi::Value DbWrap::Query(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1 || !info[0].IsString()) {
+        Napi::TypeError::New(env, "Expected (sql: string, ...params: object)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+
+    std::string sql = info[0].As<Napi::String>().Utf8Value();
+
+    soci::values binds;
+    bool hasBinds = false;
+
+    for (size_t i = 1; i < info.Length(); ++i) {
+        if (!info[i].IsObject() || info[i].IsNull() || info[i].IsArray()) {
+            Napi::TypeError::New(env, "Bind parameters must be plain objects")
+                .ThrowAsJavaScriptException();
+            return env.Undefined();
+        }
+
+        hasBinds = true;
+        Napi::Object obj = info[i].As<Napi::Object>();
+        auto names = obj.GetPropertyNames();
+
+        for (uint32_t k = 0; k < names.Length(); ++k) {
+            std::string key = names.Get(k).As<Napi::String>().Utf8Value();
+            Napi::Value val = obj.Get(key);
+
+            if (val.IsNull() || val.IsUndefined()) {
+                std::optional<int> nullVal;
+                binds.set(key, nullVal, soci::i_null);
+            } else if (val.IsString()) {
+                binds.set(key, val.As<Napi::String>().Utf8Value());
+            } else if (val.IsNumber()) {
+                double d = val.As<Napi::Number>().DoubleValue();
+                if (d == static_cast<int64_t>(d) && d >= -9007199254740992.0 && d <= 9007199254740992.0) {
+                    binds.set(key, static_cast<int>(d));
+                } else {
+                    binds.set(key, d);
+                }
+            } else if (val.IsBoolean()) {
+                binds.set(key, val.As<Napi::Boolean>().Value());
+            } else {
+                json j = NapiToJson(val);
+                binds.set(key, j);
+            }
+        }
+    }
+
+    auto deferred = Napi::Promise::Deferred::New(env);
+    auto* worker = new DbQueryWorker(env, m_db, std::move(sql), std::move(binds), hasBinds, deferred);
+    worker->Queue();
+
+    return deferred.Promise();
+}
+
+Napi::Value DbWrap::IsConnected(const Napi::CallbackInfo& info) {
+    return Napi::Boolean::New(info.Env(), m_db && m_db->isConnected());
+}

--- a/bindings/node/src/db_wrap.h
+++ b/bindings/node/src/db_wrap.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <napi.h>
+#include <mantisbase/core/database.h>
+
+class DbWrap : public Napi::ObjectWrap<DbWrap> {
+public:
+    static Napi::Function GetClass(Napi::Env env);
+    static Napi::Object NewInstance(Napi::Env env, mb::Database* db);
+    DbWrap(const Napi::CallbackInfo& info);
+
+private:
+    Napi::Value Query(const Napi::CallbackInfo& info);
+    Napi::Value IsConnected(const Napi::CallbackInfo& info);
+
+    mb::Database* m_db = nullptr;
+    static Napi::FunctionReference s_constructor;
+};

--- a/bindings/node/src/request_wrap.cpp
+++ b/bindings/node/src/request_wrap.cpp
@@ -1,0 +1,117 @@
+#include "request_wrap.h"
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+Napi::FunctionReference RequestWrap::s_constructor;
+
+static Napi::Value JsonToNapi(Napi::Env env, const json& j) {
+    if (j.is_null()) return env.Null();
+    if (j.is_boolean()) return Napi::Boolean::New(env, j.get<bool>());
+    if (j.is_number_integer()) return Napi::Number::New(env, j.get<int64_t>());
+    if (j.is_number_float()) return Napi::Number::New(env, j.get<double>());
+    if (j.is_string()) return Napi::String::New(env, j.get<std::string>());
+    if (j.is_array()) {
+        auto arr = Napi::Array::New(env, j.size());
+        for (size_t i = 0; i < j.size(); ++i) {
+            arr.Set(static_cast<uint32_t>(i), JsonToNapi(env, j[i]));
+        }
+        return arr;
+    }
+    if (j.is_object()) {
+        auto obj = Napi::Object::New(env);
+        for (auto it = j.begin(); it != j.end(); ++it) {
+            obj.Set(it.key(), JsonToNapi(env, it.value()));
+        }
+        return obj;
+    }
+    return env.Undefined();
+}
+
+Napi::Function RequestWrap::GetClass(Napi::Env env) {
+    auto func = DefineClass(env, "MantisRequest", {
+        InstanceMethod<&RequestWrap::PathParam>("pathParam"),
+        InstanceMethod<&RequestWrap::QueryParam>("queryParam"),
+        InstanceMethod<&RequestWrap::Header>("header"),
+        InstanceMethod<&RequestWrap::Json>("json"),
+        InstanceMethod<&RequestWrap::Body>("body"),
+        InstanceAccessor<&RequestWrap::GetMethod>("method"),
+        InstanceAccessor<&RequestWrap::GetPath>("path"),
+        InstanceAccessor<&RequestWrap::GetRemoteAddr>("remoteAddr"),
+    });
+
+    s_constructor = Napi::Persistent(func);
+    s_constructor.SuppressDestruct();
+
+    return func;
+}
+
+RequestWrap::RequestWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<RequestWrap>(info) {
+
+    if (info.Length() > 0 && info[0].IsExternal()) {
+        m_req = info[0].As<Napi::External<mb::MantisRequest>>().Data();
+    }
+}
+
+Napi::Object RequestWrap::NewInstance(Napi::Env env, mb::MantisRequest* req) {
+    return s_constructor.New({Napi::External<mb::MantisRequest>::New(env, req)});
+}
+
+Napi::Value RequestWrap::PathParam(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsString()) {
+        Napi::TypeError::New(env, "Expected (name: string)").ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+    return Napi::String::New(env, m_req->getPathParamValue(name));
+}
+
+Napi::Value RequestWrap::QueryParam(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsString()) {
+        Napi::TypeError::New(env, "Expected (name: string)").ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+    return Napi::String::New(env, m_req->getQueryParamValue(name));
+}
+
+Napi::Value RequestWrap::Header(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsString()) {
+        Napi::TypeError::New(env, "Expected (name: string)").ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+    return Napi::String::New(env, m_req->getHeaderValue(name));
+}
+
+Napi::Value RequestWrap::Json(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    try {
+        json j = m_req->jsonBody();
+        return JsonToNapi(env, j);
+    } catch (const std::exception& e) {
+        Napi::Error::New(env, std::string("Failed to parse JSON body: ") + e.what())
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+}
+
+Napi::Value RequestWrap::Body(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), m_req->getBody());
+}
+
+Napi::Value RequestWrap::GetMethod(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), m_req->getMethod());
+}
+
+Napi::Value RequestWrap::GetPath(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), m_req->getPath());
+}
+
+Napi::Value RequestWrap::GetRemoteAddr(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), m_req->getRemoteAddr());
+}

--- a/bindings/node/src/request_wrap.h
+++ b/bindings/node/src/request_wrap.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <napi.h>
+#include <mantisbase/core/http.h>
+
+class RequestWrap : public Napi::ObjectWrap<RequestWrap> {
+public:
+    static Napi::Function GetClass(Napi::Env env);
+    RequestWrap(const Napi::CallbackInfo& info);
+
+    static Napi::Object NewInstance(Napi::Env env, mb::MantisRequest* req);
+
+private:
+    Napi::Value PathParam(const Napi::CallbackInfo& info);
+    Napi::Value QueryParam(const Napi::CallbackInfo& info);
+    Napi::Value Header(const Napi::CallbackInfo& info);
+    Napi::Value Json(const Napi::CallbackInfo& info);
+    Napi::Value Body(const Napi::CallbackInfo& info);
+    Napi::Value GetMethod(const Napi::CallbackInfo& info);
+    Napi::Value GetPath(const Napi::CallbackInfo& info);
+    Napi::Value GetRemoteAddr(const Napi::CallbackInfo& info);
+
+    mb::MantisRequest* m_req = nullptr;
+
+    static Napi::FunctionReference s_constructor;
+};

--- a/bindings/node/src/response_wrap.cpp
+++ b/bindings/node/src/response_wrap.cpp
@@ -1,0 +1,148 @@
+#include "response_wrap.h"
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+Napi::FunctionReference ResponseWrap::s_constructor;
+
+static json NapiToJson(Napi::Value val) {
+    if (val.IsNull() || val.IsUndefined()) return nullptr;
+    if (val.IsBoolean()) return val.As<Napi::Boolean>().Value();
+    if (val.IsNumber()) {
+        double d = val.As<Napi::Number>().DoubleValue();
+        if (d == static_cast<int64_t>(d) && d >= -9007199254740992.0 && d <= 9007199254740992.0) {
+            return static_cast<int64_t>(d);
+        }
+        return d;
+    }
+    if (val.IsString()) return val.As<Napi::String>().Utf8Value();
+    if (val.IsArray()) {
+        auto arr = val.As<Napi::Array>();
+        json j = json::array();
+        for (uint32_t i = 0; i < arr.Length(); ++i) {
+            j.push_back(NapiToJson(arr.Get(i)));
+        }
+        return j;
+    }
+    if (val.IsObject()) {
+        auto obj = val.As<Napi::Object>();
+        json j = json::object();
+        auto names = obj.GetPropertyNames();
+        for (uint32_t i = 0; i < names.Length(); ++i) {
+            std::string key = names.Get(i).As<Napi::String>().Utf8Value();
+            j[key] = NapiToJson(obj.Get(key));
+        }
+        return j;
+    }
+    return nullptr;
+}
+
+Napi::Function ResponseWrap::GetClass(Napi::Env env) {
+    auto func = DefineClass(env, "MantisResponse", {
+        InstanceMethod<&ResponseWrap::JsonMethod>("json"),
+        InstanceMethod<&ResponseWrap::Html>("html"),
+        InstanceMethod<&ResponseWrap::Text>("text"),
+        InstanceMethod<&ResponseWrap::Send>("send"),
+        InstanceMethod<&ResponseWrap::Redirect>("redirect"),
+        InstanceMethod<&ResponseWrap::SetHeader>("setHeader"),
+    });
+
+    s_constructor = Napi::Persistent(func);
+    s_constructor.SuppressDestruct();
+
+    return func;
+}
+
+ResponseWrap::ResponseWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<ResponseWrap>(info) {
+
+    if (info.Length() > 0 && info[0].IsExternal()) {
+        m_res = info[0].As<Napi::External<mb::MantisResponse>>().Data();
+    }
+}
+
+Napi::Object ResponseWrap::NewInstance(Napi::Env env, mb::MantisResponse* res) {
+    return s_constructor.New({Napi::External<mb::MantisResponse>::New(env, res)});
+}
+
+Napi::Value ResponseWrap::JsonMethod(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Expected (statusCode: number, data: object)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    int statusCode = info[0].As<Napi::Number>().Int32Value();
+    json data = NapiToJson(info[1]);
+    m_res->sendJSON(statusCode, data);
+    return env.Undefined();
+}
+
+Napi::Value ResponseWrap::Html(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsString()) {
+        Napi::TypeError::New(env, "Expected (statusCode: number, body: string)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    int statusCode = info[0].As<Napi::Number>().Int32Value();
+    std::string body = info[1].As<Napi::String>().Utf8Value();
+    m_res->sendHtml(statusCode, body);
+    return env.Undefined();
+}
+
+Napi::Value ResponseWrap::Text(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsString()) {
+        Napi::TypeError::New(env, "Expected (statusCode: number, body: string)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    int statusCode = info[0].As<Napi::Number>().Int32Value();
+    std::string body = info[1].As<Napi::String>().Utf8Value();
+    m_res->sendText(statusCode, body);
+    return env.Undefined();
+}
+
+Napi::Value ResponseWrap::Send(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Expected (statusCode: number, body?: string, contentType?: string)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    int statusCode = info[0].As<Napi::Number>().Int32Value();
+    std::string body = (info.Length() > 1 && info[1].IsString())
+        ? info[1].As<Napi::String>().Utf8Value() : "";
+    std::string contentType = (info.Length() > 2 && info[2].IsString())
+        ? info[2].As<Napi::String>().Utf8Value() : "text/plain";
+    m_res->send(statusCode, body, contentType);
+    return env.Undefined();
+}
+
+Napi::Value ResponseWrap::Redirect(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 1 || !info[0].IsString()) {
+        Napi::TypeError::New(env, "Expected (url: string)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    std::string url = info[0].As<Napi::String>().Utf8Value();
+    int status = (info.Length() > 1 && info[1].IsNumber())
+        ? info[1].As<Napi::Number>().Int32Value() : 302;
+    m_res->setRedirect(url, status);
+    return env.Undefined();
+}
+
+Napi::Value ResponseWrap::SetHeader(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsString()) {
+        Napi::TypeError::New(env, "Expected (name: string, value: string)")
+            .ThrowAsJavaScriptException();
+        return env.Undefined();
+    }
+    std::string name = info[0].As<Napi::String>().Utf8Value();
+    std::string value = info[1].As<Napi::String>().Utf8Value();
+    m_res->setHeader(name, value);
+    return env.Undefined();
+}

--- a/bindings/node/src/response_wrap.h
+++ b/bindings/node/src/response_wrap.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <napi.h>
+#include <mantisbase/core/http.h>
+
+class ResponseWrap : public Napi::ObjectWrap<ResponseWrap> {
+public:
+    static Napi::Function GetClass(Napi::Env env);
+    ResponseWrap(const Napi::CallbackInfo& info);
+
+    static Napi::Object NewInstance(Napi::Env env, mb::MantisResponse* res);
+
+private:
+    Napi::Value JsonMethod(const Napi::CallbackInfo& info);
+    Napi::Value Html(const Napi::CallbackInfo& info);
+    Napi::Value Text(const Napi::CallbackInfo& info);
+    Napi::Value Send(const Napi::CallbackInfo& info);
+    Napi::Value Redirect(const Napi::CallbackInfo& info);
+    Napi::Value SetHeader(const Napi::CallbackInfo& info);
+
+    mb::MantisResponse* m_res = nullptr;
+
+    static Napi::FunctionReference s_constructor;
+};

--- a/bindings/node/src/router_wrap.cpp
+++ b/bindings/node/src/router_wrap.cpp
@@ -1,0 +1,142 @@
+#include "router_wrap.h"
+#include "request_wrap.h"
+#include "response_wrap.h"
+#include <future>
+#include <memory>
+
+Napi::FunctionReference RouterWrap::s_constructor;
+
+Napi::Function RouterWrap::GetClass(Napi::Env env) {
+    auto func = DefineClass(env, "Router", {
+        InstanceMethod<&RouterWrap::Get>("get"),
+        InstanceMethod<&RouterWrap::Post>("post"),
+        InstanceMethod<&RouterWrap::Patch>("patch"),
+        InstanceMethod<&RouterWrap::Delete>("delete"),
+    });
+
+    s_constructor = Napi::Persistent(func);
+    s_constructor.SuppressDestruct();
+
+    return func;
+}
+
+RouterWrap::RouterWrap(const Napi::CallbackInfo& info)
+    : Napi::ObjectWrap<RouterWrap>(info) {
+
+    if (info.Length() > 0 && info[0].IsExternal()) {
+        m_router = info[0].As<Napi::External<mb::Router>>().Data();
+    }
+}
+
+RouterWrap::~RouterWrap() {
+    for (auto& tsfn : m_tsfns) {
+        tsfn.Release();
+    }
+    m_tsfns.clear();
+}
+
+Napi::Object RouterWrap::NewInstance(Napi::Env env, mb::Router* router) {
+    Napi::Object obj = s_constructor.New({Napi::External<mb::Router>::New(env, router)});
+    return obj;
+}
+
+void RouterWrap::RegisterRoute(const Napi::CallbackInfo& info,
+    void(mb::Router::*method)(const std::string&, const mb::HandlerFn&, const mb::Middlewares&)) {
+
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 2 || !info[0].IsString() || !info[1].IsFunction()) {
+        Napi::TypeError::New(env, "Expected (path: string, handler: function)")
+            .ThrowAsJavaScriptException();
+        return;
+    }
+
+    if (!m_router) {
+        Napi::Error::New(env, "Router not initialized").ThrowAsJavaScriptException();
+        return;
+    }
+
+    std::string path = info[0].As<Napi::String>().Utf8Value();
+    Napi::Function handler = info[1].As<Napi::Function>();
+
+    auto tsfn = Napi::ThreadSafeFunction::New(
+        env, handler, "MantisRouteHandler", 0, 1);
+
+    m_tsfns.push_back(tsfn);
+
+    mb::HandlerFn handlerFn = [tsfn](mb::MantisRequest& req, mb::MantisResponse& res) mutable {
+        auto donePtr = std::make_shared<std::promise<void>>();
+        auto future = donePtr->get_future();
+
+        auto reqPtr = &req;
+        auto resPtr = &res;
+
+        tsfn.BlockingCall(
+            [reqPtr, resPtr, donePtr](Napi::Env env, Napi::Function jsCallback) {
+                Napi::Object reqObj = RequestWrap::NewInstance(env, reqPtr);
+                Napi::Object resObj = ResponseWrap::NewInstance(env, resPtr);
+
+                Napi::Value result = jsCallback.Call({reqObj, resObj});
+
+                if (env.IsExceptionPending()) {
+                    donePtr->set_value();
+                    return;
+                }
+
+                if (result.IsPromise()) {
+                    Napi::Object promise = result.As<Napi::Object>();
+
+                    auto thenFn = Napi::Function::New(env,
+                        [donePtr](const Napi::CallbackInfo& cbInfo) {
+                            donePtr->set_value();
+                        });
+
+                    auto catchFn = Napi::Function::New(env,
+                        [donePtr](const Napi::CallbackInfo& cbInfo) {
+                            donePtr->set_value();
+                        });
+
+                    Napi::Value thenResult = promise.Get("then")
+                        .As<Napi::Function>()
+                        .Call(promise, {thenFn});
+
+                    if (!env.IsExceptionPending() && thenResult.IsObject()) {
+                        thenResult.As<Napi::Object>()
+                            .Get("catch")
+                            .As<Napi::Function>()
+                            .Call(thenResult.As<Napi::Object>(), {catchFn});
+                    }
+
+                    if (env.IsExceptionPending()) {
+                        donePtr->set_value();
+                    }
+                } else {
+                    donePtr->set_value();
+                }
+            });
+
+        future.wait();
+    };
+
+    (m_router->*method)(path, handlerFn, {});
+}
+
+Napi::Value RouterWrap::Get(const Napi::CallbackInfo& info) {
+    RegisterRoute(info, &mb::Router::Get);
+    return info.Env().Undefined();
+}
+
+Napi::Value RouterWrap::Post(const Napi::CallbackInfo& info) {
+    RegisterRoute(info, static_cast<void(mb::Router::*)(const std::string&, const mb::HandlerFn&, const mb::Middlewares&)>(&mb::Router::Post));
+    return info.Env().Undefined();
+}
+
+Napi::Value RouterWrap::Patch(const Napi::CallbackInfo& info) {
+    RegisterRoute(info, static_cast<void(mb::Router::*)(const std::string&, const mb::HandlerFn&, const mb::Middlewares&)>(&mb::Router::Patch));
+    return info.Env().Undefined();
+}
+
+Napi::Value RouterWrap::Delete(const Napi::CallbackInfo& info) {
+    RegisterRoute(info, &mb::Router::Delete);
+    return info.Env().Undefined();
+}

--- a/bindings/node/src/router_wrap.h
+++ b/bindings/node/src/router_wrap.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <napi.h>
+#include <mantisbase/core/router.h>
+#include <mantisbase/core/types.h>
+#include <vector>
+
+class RouterWrap : public Napi::ObjectWrap<RouterWrap> {
+public:
+    static Napi::Function GetClass(Napi::Env env);
+    RouterWrap(const Napi::CallbackInfo& info);
+    ~RouterWrap();
+
+    void SetRouter(mb::Router* router) { m_router = router; }
+
+    static Napi::Object NewInstance(Napi::Env env, mb::Router* router);
+
+private:
+    Napi::Value Get(const Napi::CallbackInfo& info);
+    Napi::Value Post(const Napi::CallbackInfo& info);
+    Napi::Value Patch(const Napi::CallbackInfo& info);
+    Napi::Value Delete(const Napi::CallbackInfo& info);
+
+    void RegisterRoute(const Napi::CallbackInfo& info,
+        void(mb::Router::*method)(const std::string&, const mb::HandlerFn&, const mb::Middlewares&));
+
+    mb::Router* m_router = nullptr;
+    std::vector<Napi::ThreadSafeFunction> m_tsfns;
+
+    static Napi::FunctionReference s_constructor;
+};

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.22)
+project(mantisbase-python LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# When included from the parent CMakeLists.txt, nanobind may not be installed.
+# Skip gracefully so the rest of the build can proceed.
+find_package(Python 3.9 COMPONENTS Interpreter Development.Module QUIET)
+if(NOT Python_FOUND)
+    message(STATUS "[mantisbase-python] Python >= 3.9 not found; skipping Python bindings.")
+    message(STATUS "  Build via: pip install -e bindings/python")
+    return()
+endif()
+
+# Locate nanobind via Python's package metadata
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_VARIABLE nanobind_ROOT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _nb_result
+    ERROR_QUIET
+)
+if(NOT _nb_result EQUAL 0)
+    message(STATUS "[mantisbase-python] nanobind not found; skipping Python bindings.")
+    message(STATUS "  Install nanobind: pip install nanobind")
+    return()
+endif()
+
+find_package(nanobind CONFIG REQUIRED)
+
+nanobind_add_module(mantisbase_python
+    src/module.cpp
+    src/app_bind.cpp
+    src/router_bind.cpp
+    src/request_bind.cpp
+    src/response_bind.cpp
+    src/db_bind.cpp
+)
+
+# Link against mantisbase shared library
+if(TARGET mb::shared)
+    target_link_libraries(mantisbase_python PRIVATE mb::shared)
+else()
+    find_library(MANTISBASE_LIB mantisbase REQUIRED)
+    find_path(MANTISBASE_INCLUDE mantisbase/mantisbase.h REQUIRED)
+    target_link_libraries(mantisbase_python PRIVATE ${MANTISBASE_LIB})
+    target_include_directories(mantisbase_python PRIVATE ${MANTISBASE_INCLUDE})
+endif()
+
+set_target_properties(mantisbase_python PROPERTIES
+    OUTPUT_NAME "mantisbase"
+)
+
+install(TARGETS mantisbase_python LIBRARY DESTINATION .)

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,0 +1,92 @@
+# mantisbase (Python)
+
+Python bindings for [mantisbase](https://github.com/allankoechke/mantisbase), a
+C++20 single-binary backend-as-a-service. Import it like Flask and drive the
+whole server from Python.
+
+```bash
+pip install mantisbase
+```
+
+```python
+import mantisbase
+
+app = mantisbase.App(port=8080, data_dir="./data")
+
+
+@app.router.get("/hello/{name}")
+def hello(req, res):
+    res.json(200, {"message": f"Hello, {req.path_param('name')}!"})
+
+
+@app.router.post("/items")
+def create_item(req, res):
+    body = req.json()
+    rows = app.db.query("INSERT INTO items (name) VALUES (:name) RETURNING *",
+                        {"name": body["name"]})
+    res.json(201, rows[0])
+
+
+app.start()  # blocks until stop() is called
+```
+
+## API
+
+### `App(**config)`
+
+Keyword arguments mirror the CLI flags: `port`, `host`, `data_dir`, `db_type`,
+`db_url`, `public_dir`, `scripts_dir`, `migrations_dir`, `pool_size`, `dev`,
+`skip_admin_setup`. `secret_key` sets the `MB_JWT_SECRET` environment variable.
+
+- `start(blocking=True)` — run the HTTP server. Pass `blocking=False` to run it
+  on a background thread.
+- `stop()` — shut the server down.
+- `router` / `db` — the `Router` and `Database` instances.
+
+### `Router`
+
+`get(path, handler=None)`, `post(...)`, `patch(...)`, `delete(...)`. Called with
+only a path they return a decorator, so both styles work:
+
+```python
+app.router.get("/a", handler)
+
+@app.router.get("/b")
+def handler_b(req, res): ...
+```
+
+### `MantisRequest`
+
+`path_param(name)`, `query_param(name)`, `header(name)`, `json()`, `body()`,
+and the read-only properties `method`, `path`, `remote_addr`.
+
+### `MantisResponse`
+
+`json(status, data)`, `html(status, body)`, `text(status, body)`,
+`send(status, data, content_type)`, `redirect(url, status=302)`,
+`set_header(name, value)`.
+
+### `Database`
+
+`query(sql, *params)` where each param is a dict of named binds. Returns a list
+of dicts keyed by column name. The GIL is released for the duration of the
+query.
+
+## Threading
+
+Route handlers are invoked from mantisbase's C++ worker threads, and the GIL is
+acquired before each call. Python handlers therefore serialise against each
+other — the same model as Flask's default threaded server.
+
+## Building from source
+
+```bash
+pip install -e bindings/python
+```
+
+Requires CMake >= 3.22, a C++20 compiler, and the mantisbase shared library
+(`cmake -DMB_BUILD_SHARED_LIB=ON -DMB_BUILD_BINDINGS=ON ..`).
+
+## License
+
+MIT

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.0"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "mantisbase"
+version = "0.1.0"
+description = "Python bindings for mantisbase – Flask-style HTTP server backed by a C++ engine"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9"
+authors = [{ name = "Allan Koech" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C++",
+    "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
+]
+
+[tool.scikit-build]
+cmake.build-type = "Release"
+wheel.packages = []

--- a/bindings/python/src/app_bind.cpp
+++ b/bindings/python/src/app_bind.cpp
@@ -1,0 +1,113 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <mantisbase/mantisbase.h>
+#include <nlohmann/json.hpp>
+#include <thread>
+#include <atomic>
+#include <memory>
+#include <cstdlib>
+
+namespace nb = nanobind;
+using json = nlohmann::json;
+
+class PyApp {
+public:
+    PyApp(nb::kwargs kwargs) {
+        json config = json::object();
+        config["serve"] = json::object();
+
+        if (kwargs.contains("port"))
+            config["serve"]["port"] = nb::cast<int>(kwargs["port"]);
+        if (kwargs.contains("host"))
+            config["serve"]["host"] = nb::cast<std::string>(kwargs["host"]);
+        if (kwargs.contains("data_dir"))
+            config["data-dir"] = nb::cast<std::string>(kwargs["data_dir"]);
+        if (kwargs.contains("db_type"))
+            config["db"] = nb::cast<std::string>(kwargs["db_type"]);
+        if (kwargs.contains("db_url"))
+            config["db_url"] = nb::cast<std::string>(kwargs["db_url"]);
+        if (kwargs.contains("public_dir"))
+            config["public-dir"] = nb::cast<std::string>(kwargs["public_dir"]);
+        if (kwargs.contains("scripts_dir"))
+            config["scripts-dir"] = nb::cast<std::string>(kwargs["scripts_dir"]);
+        if (kwargs.contains("migrations_dir"))
+            config["migrations-dir"] = nb::cast<std::string>(kwargs["migrations_dir"]);
+        if (kwargs.contains("pool_size"))
+            config["serve"]["pool-size"] = nb::cast<int>(kwargs["pool_size"]);
+        // `dev` is a presence-only flag in MantisBase::create() -- only add the
+        // key when the caller actually asked for dev mode.
+        if (kwargs.contains("dev") && nb::cast<bool>(kwargs["dev"]))
+            config["dev"] = true;
+        if (kwargs.contains("skip_admin_setup"))
+            config["serve"]["skip-admin-setup"] = nb::cast<bool>(kwargs["skip_admin_setup"]);
+
+        // MantisBase reads the JWT signing key from the environment, so there is
+        // no CLI/config equivalent to forward it through.
+        if (kwargs.contains("secret_key")) {
+            const auto secret = nb::cast<std::string>(kwargs["secret_key"]);
+#ifdef _WIN32
+            _putenv_s("MB_JWT_SECRET", secret.c_str());
+#else
+            ::setenv("MB_JWT_SECRET", secret.c_str(), 1);
+#endif
+        }
+
+        m_app = mb::MantisBase::create(config);
+        if (!m_app)
+            throw std::runtime_error("Failed to create MantisBase instance");
+    }
+
+    ~PyApp() {
+        if (m_running.load()) {
+            m_app->close();
+            if (m_serverThread.joinable())
+                m_serverThread.join();
+        }
+    }
+
+    void start(bool blocking) {
+        if (m_running.load())
+            return;
+
+        m_running.store(true);
+
+        if (blocking) {
+            nb::gil_scoped_release release;
+            m_app->run();
+            m_running.store(false);
+        } else {
+            m_serverThread = std::thread([this]() {
+                m_app->run();
+                m_running.store(false);
+            });
+        }
+    }
+
+    void stop() {
+        if (!m_running.load())
+            return;
+
+        m_app->close();
+        if (m_serverThread.joinable())
+            m_serverThread.join();
+        m_running.store(false);
+    }
+
+    mb::Router& router() { return m_app->router(); }
+    mb::Database& db() { return m_app->db(); }
+    mb::MantisBase& app() { return *m_app; }
+
+private:
+    std::unique_ptr<mb::MantisBase> m_app;
+    std::thread m_serverThread;
+    std::atomic<bool> m_running{false};
+};
+
+void register_app(nb::module_& m) {
+    nb::class_<PyApp>(m, "App")
+        .def(nb::init<nb::kwargs>())
+        .def("start", &PyApp::start, nb::arg("blocking") = true)
+        .def("stop", &PyApp::stop)
+        .def_prop_ro("router", &PyApp::router, nb::rv_policy::reference_internal)
+        .def_prop_ro("db", &PyApp::db, nb::rv_policy::reference_internal);
+}

--- a/bindings/python/src/db_bind.cpp
+++ b/bindings/python/src/db_bind.cpp
@@ -1,0 +1,145 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <mantisbase/core/database.h>
+#include <soci/soci.h>
+#include <nlohmann/json.hpp>
+
+namespace nb = nanobind;
+using json = nlohmann::json;
+
+static nb::object json_to_python(const json& j) {
+    if (j.is_null()) return nb::none();
+    if (j.is_boolean()) return nb::cast(j.get<bool>());
+    if (j.is_number_integer()) return nb::cast(j.get<int64_t>());
+    if (j.is_number_float()) return nb::cast(j.get<double>());
+    if (j.is_string()) return nb::cast(j.get<std::string>());
+    if (j.is_array()) {
+        nb::list lst;
+        for (const auto& elem : j)
+            lst.append(json_to_python(elem));
+        return lst;
+    }
+    if (j.is_object()) {
+        nb::dict d;
+        for (auto it = j.begin(); it != j.end(); ++it)
+            d[nb::cast(it.key())] = json_to_python(it.value());
+        return d;
+    }
+    return nb::none();
+}
+
+static json soci_row_to_json(const soci::row& row) {
+    json obj = json::object();
+    for (size_t i = 0; i < row.size(); ++i) {
+        const auto& props = row.get_properties(i);
+        const std::string& name = props.get_name();
+
+        if (row.get_indicator(i) == soci::i_null) {
+            obj[name] = nullptr;
+            continue;
+        }
+
+        switch (props.get_db_type()) {
+            case soci::db_string:
+            case soci::db_xml:
+                obj[name] = row.get<std::string>(i);
+                break;
+            case soci::db_double:
+                obj[name] = row.get<double>(i);
+                break;
+            case soci::db_int8:
+                obj[name] = static_cast<int64_t>(row.get<int8_t>(i));
+                break;
+            case soci::db_uint8:
+                obj[name] = static_cast<int64_t>(row.get<uint8_t>(i));
+                break;
+            case soci::db_int16:
+                obj[name] = static_cast<int64_t>(row.get<int16_t>(i));
+                break;
+            case soci::db_uint16:
+                obj[name] = static_cast<int64_t>(row.get<uint16_t>(i));
+                break;
+            case soci::db_int32:
+                obj[name] = static_cast<int64_t>(row.get<int32_t>(i));
+                break;
+            case soci::db_uint32:
+                obj[name] = static_cast<int64_t>(row.get<uint32_t>(i));
+                break;
+            case soci::db_int64:
+                obj[name] = static_cast<int64_t>(row.get<int64_t>(i));
+                break;
+            case soci::db_uint64:
+                obj[name] = static_cast<int64_t>(row.get<uint64_t>(i));
+                break;
+            case soci::db_date: {
+                std::tm t = row.get<std::tm>(i);
+                char buf[32];
+                std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &t);
+                obj[name] = std::string(buf);
+                break;
+            }
+            default:
+                obj[name] = row.get<std::string>(i);
+                break;
+        }
+    }
+    return obj;
+}
+
+void register_db(nb::module_& m) {
+    nb::class_<mb::Database>(m, "Database")
+        .def("query", [](mb::Database& self, const std::string& sql, nb::args params) -> nb::list {
+            soci::values binds;
+            bool has_binds = false;
+
+            for (size_t i = 0; i < params.size(); ++i) {
+                nb::handle param = params[i];
+                if (!nb::isinstance<nb::dict>(param))
+                    throw nb::type_error("Bind parameters must be dicts");
+
+                has_binds = true;
+                nb::dict d = nb::cast<nb::dict>(param);
+                for (auto item : d) {
+                    std::string key = nb::cast<std::string>(item.first);
+                    nb::handle val = item.second;
+
+                    if (val.is_none()) {
+                        std::optional<int> null_val;
+                        binds.set(key, null_val, soci::i_null);
+                    } else if (nb::isinstance<nb::str>(val)) {
+                        binds.set(key, nb::cast<std::string>(val));
+                    } else if (nb::isinstance<nb::bool_>(val)) {
+                        binds.set(key, nb::cast<bool>(val));
+                    } else if (nb::isinstance<nb::int_>(val)) {
+                        binds.set(key, nb::cast<int>(val));
+                    } else if (nb::isinstance<nb::float_>(val)) {
+                        binds.set(key, nb::cast<double>(val));
+                    }
+                }
+            }
+
+            json results;
+            {
+                nb::gil_scoped_release release;
+                auto session = self.session();
+
+                soci::row data_row;
+                soci::statement st = has_binds
+                    ? (session->prepare << sql, soci::use(binds), soci::into(data_row))
+                    : (session->prepare << sql, soci::into(data_row));
+                st.execute();
+
+                results = json::array();
+                while (st.fetch()) {
+                    results.push_back(soci_row_to_json(data_row));
+                }
+            }
+
+            nb::list py_results;
+            for (const auto& row : results) {
+                py_results.append(json_to_python(row));
+            }
+            return py_results;
+        }, nb::arg("sql"))
+        .def_prop_ro("connected", &mb::Database::isConnected);
+}

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -1,0 +1,19 @@
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+void register_app(nb::module_& m);
+void register_router(nb::module_& m);
+void register_request(nb::module_& m);
+void register_response(nb::module_& m);
+void register_db(nb::module_& m);
+
+NB_MODULE(mantisbase, m) {
+    m.doc() = "Python bindings for mantisbase – Flask-style HTTP server backed by a C++ engine";
+
+    register_app(m);
+    register_router(m);
+    register_request(m);
+    register_response(m);
+    register_db(m);
+}

--- a/bindings/python/src/request_bind.cpp
+++ b/bindings/python/src/request_bind.cpp
@@ -1,0 +1,53 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <mantisbase/core/http.h>
+#include <nlohmann/json.hpp>
+
+namespace nb = nanobind;
+using json = nlohmann::json;
+
+static nb::object json_to_python(const json& j) {
+    if (j.is_null()) return nb::none();
+    if (j.is_boolean()) return nb::cast(j.get<bool>());
+    if (j.is_number_integer()) return nb::cast(j.get<int64_t>());
+    if (j.is_number_float()) return nb::cast(j.get<double>());
+    if (j.is_string()) return nb::cast(j.get<std::string>());
+    if (j.is_array()) {
+        nb::list lst;
+        for (const auto& elem : j)
+            lst.append(json_to_python(elem));
+        return lst;
+    }
+    if (j.is_object()) {
+        nb::dict d;
+        for (auto it = j.begin(); it != j.end(); ++it)
+            d[nb::cast(it.key())] = json_to_python(it.value());
+        return d;
+    }
+    return nb::none();
+}
+
+void register_request(nb::module_& m) {
+    nb::class_<mb::MantisRequest>(m, "MantisRequest")
+        .def("path_param", [](mb::MantisRequest& self, const std::string& name) {
+            return self.getPathParamValue(name);
+        }, nb::arg("name"))
+        .def("query_param", [](mb::MantisRequest& self, const std::string& name) {
+            return self.getQueryParamValue(name);
+        }, nb::arg("name"))
+        .def("header", [](mb::MantisRequest& self, const std::string& name) {
+            return self.getHeaderValue(name);
+        }, nb::arg("name"))
+        .def("body", &mb::MantisRequest::getBody)
+        .def("json", [](mb::MantisRequest& self) -> nb::object {
+            try {
+                json j = self.jsonBody();
+                return json_to_python(j);
+            } catch (const std::exception& e) {
+                throw nb::value_error(e.what());
+            }
+        })
+        .def_prop_ro("method", &mb::MantisRequest::getMethod)
+        .def_prop_ro("path", &mb::MantisRequest::getPath)
+        .def_prop_ro("remote_addr", &mb::MantisRequest::getRemoteAddr);
+}

--- a/bindings/python/src/response_bind.cpp
+++ b/bindings/python/src/response_bind.cpp
@@ -1,0 +1,43 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <mantisbase/core/http.h>
+#include <nlohmann/json.hpp>
+
+namespace nb = nanobind;
+using json = nlohmann::json;
+
+static json python_to_json(nb::handle obj) {
+    if (obj.is_none()) return nullptr;
+    if (nb::isinstance<nb::bool_>(obj)) return nb::cast<bool>(obj);
+    if (nb::isinstance<nb::int_>(obj)) return nb::cast<int64_t>(obj);
+    if (nb::isinstance<nb::float_>(obj)) return nb::cast<double>(obj);
+    if (nb::isinstance<nb::str>(obj)) return nb::cast<std::string>(obj);
+    if (nb::isinstance<nb::list>(obj)) {
+        json arr = json::array();
+        for (auto item : obj)
+            arr.push_back(python_to_json(item));
+        return arr;
+    }
+    if (nb::isinstance<nb::dict>(obj)) {
+        json d = json::object();
+        for (auto item : nb::cast<nb::dict>(obj))
+            d[nb::cast<std::string>(item.first)] = python_to_json(item.second);
+        return d;
+    }
+    return nullptr;
+}
+
+void register_response(nb::module_& m) {
+    nb::class_<mb::MantisResponse>(m, "MantisResponse")
+        .def("json", [](mb::MantisResponse& self, int status, nb::handle data) {
+            self.sendJSON(status, python_to_json(data));
+        }, nb::arg("status"), nb::arg("data"))
+        .def("html", &mb::MantisResponse::sendHtml, nb::arg("status"), nb::arg("body"))
+        .def("text", &mb::MantisResponse::sendText, nb::arg("status"), nb::arg("body"))
+        .def("send", &mb::MantisResponse::send,
+             nb::arg("status"), nb::arg("data") = "", nb::arg("content_type") = "text/plain")
+        .def("redirect", &mb::MantisResponse::setRedirect,
+             nb::arg("url"), nb::arg("status") = 302)
+        .def("set_header", &mb::MantisResponse::setHeader,
+             nb::arg("name"), nb::arg("value"));
+}

--- a/bindings/python/src/router_bind.cpp
+++ b/bindings/python/src/router_bind.cpp
@@ -1,0 +1,57 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <mantisbase/core/router.h>
+#include <mantisbase/core/http.h>
+#include <mantisbase/core/types.h>
+
+namespace nb = nanobind;
+
+using RegisterMethod = void(mb::Router::*)(const std::string&, const mb::HandlerFn&, const mb::Middlewares&);
+
+static void register_route(mb::Router& router, const std::string& path,
+                           nb::callable handler, RegisterMethod method) {
+    nb::callable stored_handler(handler);
+
+    mb::HandlerFn fn = [stored_handler](mb::MantisRequest& req, mb::MantisResponse& res) {
+        nb::gil_scoped_acquire gil;
+        try {
+            stored_handler(&req, &res);
+        } catch (nb::python_error& e) {
+            e.restore();
+        }
+    };
+
+    (router.*method)(path, fn, {});
+}
+
+static nb::object make_route_method(mb::Router& router, const std::string& path,
+                                    nb::object handler_or_none, RegisterMethod method) {
+    if (!handler_or_none.is_none()) {
+        register_route(router, path, nb::callable(handler_or_none), method);
+        return handler_or_none;
+    }
+
+    mb::Router* router_ptr = &router;
+    return nb::cpp_function([router_ptr, path, method](nb::callable handler) -> nb::callable {
+        register_route(*router_ptr, path, handler, method);
+        return handler;
+    });
+}
+
+void register_router(nb::module_& m) {
+    nb::class_<mb::Router>(m, "Router")
+        .def("get", [](mb::Router& self, const std::string& path, nb::object handler) {
+            return make_route_method(self, path, handler, &mb::Router::Get);
+        }, nb::arg("path"), nb::arg("handler") = nb::none())
+        .def("post", [](mb::Router& self, const std::string& path, nb::object handler) {
+            return make_route_method(self, path, handler,
+                static_cast<RegisterMethod>(&mb::Router::Post));
+        }, nb::arg("path"), nb::arg("handler") = nb::none())
+        .def("patch", [](mb::Router& self, const std::string& path, nb::object handler) {
+            return make_route_method(self, path, handler,
+                static_cast<RegisterMethod>(&mb::Router::Patch));
+        }, nb::arg("path"), nb::arg("handler") = nb::none())
+        .def("delete", [](mb::Router& self, const std::string& path, nb::object handler) {
+            return make_route_method(self, path, handler, &mb::Router::Delete);
+        }, nb::arg("path"), nb::arg("handler") = nb::none());
+}

--- a/include/mantisbase/core/database.h
+++ b/include/mantisbase/core/database.h
@@ -16,6 +16,7 @@
 #endif
 
 #include "../mantisbase.h"
+#include "../export.h"
 #include "../utils/utils.h"
 #include "logger/logger.h"
 
@@ -37,7 +38,7 @@ namespace mb {
      * *session << "SELECT * FROM users", soci::into(rows);
      * @endcode
      */
-    class Database {
+    class MANTISBASE_API Database {
     public:
         /**
          * @brief Construct database instance bound to an application.

--- a/include/mantisbase/core/http.h
+++ b/include/mantisbase/core/http.h
@@ -12,6 +12,7 @@
 #include "context_store.h"
 #include "../utils/utils.h"
 #include "types.h"
+#include "../export.h"
 #include <fstream>
 #include <unordered_map>
 #include <drogon/HttpRequest.h>
@@ -43,7 +44,7 @@ namespace mb {
      * underlying Drogon request via `set()` / `getOr()`, not a global context.
      * Use `mbApp()` (from @ref IMantisBase) to reach application services.
      */
-    class MantisRequest: public IMantisBase {
+    class MANTISBASE_API MantisRequest: public IMantisBase {
         drogon::HttpRequestPtr m_req;
         std::unordered_map<std::string, std::string> m_pathParams;
 
@@ -94,6 +95,14 @@ namespace mb {
 
         const drogon::HttpRequestPtr& drogonRequest() const;
 
+        /**
+         * @brief Parsed JSON body, or an empty object when absent or malformed.
+         *
+         * Convenience wrapper over getBodyAsJson() for callers -- notably the
+         * language bindings -- that want a value rather than a (value, error) pair.
+         */
+        json jsonBody() const;
+
         template<typename T>
         void set(const std::string &key, T value) {
             m_req->attributes()->insert(key, value);
@@ -121,7 +130,7 @@ namespace mb {
      * Constructed by the router for each request; use `sendJSON()`, `send()`,
      * or header helpers to build the outgoing response.
      */
-    class MantisResponse: public IMantisBase {
+    class MANTISBASE_API MantisResponse: public IMantisBase {
         drogon::HttpResponsePtr m_res;
 
     public:

--- a/include/mantisbase/core/router.h
+++ b/include/mantisbase/core/router.h
@@ -12,13 +12,14 @@
 #include "models/entity.h"
 #include "../utils/utils.h"
 #include "types.h"
+#include "../export.h"
 #include "drogon/drogon_callbacks.h"
 #include "mantisbase/utils/snowflake.hpp"
 
 namespace mb {
     class SSEMgr;
 
-    class Router: public IMantisBase {
+    class MANTISBASE_API Router: public IMantisBase {
     public:
         explicit Router(const MantisBase& app);
         ~Router();

--- a/include/mantisbase/core/types.h
+++ b/include/mantisbase/core/types.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include "../export.h"
 
 namespace mb {
     class MantisBase;
@@ -57,7 +58,7 @@ namespace mb {
      * });
      * @endcode
      */
-    class IMantisBase {
+    class MANTISBASE_API IMantisBase {
         const MantisBase& m_app;
 
     public:

--- a/src/core/http_request.cpp
+++ b/src/core/http_request.cpp
@@ -163,6 +163,14 @@ namespace mb {
 
     const drogon::HttpRequestPtr & MantisRequest::drogonRequest() const { return m_req; }
 
+    json MantisRequest::jsonBody() const {
+        auto [obj, err] = getBodyAsJson();
+        if (!err.empty()) {
+            return json::object();
+        }
+        return obj;
+    }
+
 #ifdef MB_SCRIPTING_ENABLED
     void MantisRequest::registerDuktapeMethods() {
         // TODO: Re-enable after Drogon migration


### PR DESCRIPTION
Implements scripting support tracked in [allankoechke/idea_board#35](https://github.com/allankoechke/idea_board/issues/35).

Exposes the existing public C++ API as native language bindings so users can `npm install mantisbase` or `pip install mantisbase` and write Express-/Flask-style backends without touching C++ — create an App, register routes with JS/Python handler functions, query the database, and start the server.

```js
const { App } = require('mantisbase')
const app = new App({ port: 8080, dataDir: './data' })
app.router.get('/hello/:name', (req, res) => {
    res.json(200, { message: `Hello, ${req.pathParam('name')}!` })
})
app.start()
```

```python
import mantisbase
app = mantisbase.App(port=8080, data_dir="./data")

@app.router.get("/hello/{name}")
def hello(req, res):
    res.json(200, {"message": f"Hello, {req.path_param('name')}!"})

app.start()
```

## What's in here

**Core (`CMakeLists.txt`, `include/`, `src/core/http_request.cpp`)** — 41 lines total, additive:
- `MANTISBASE_API` on `IMantisBase`, `Database`, `Router`, `MantisRequest`, `MantisResponse` so they cross the DLL boundary (`MantisBase` already had it).
- `install()` rules for `mantisbase-dll` and the public headers, so a binding build can consume the shared library without rebuilding the project.
- `MantisRequest::jsonBody()` — value-returning wrapper over `getBodyAsJson()` for callers that don't want the `(value, error)` pair.
- `MB_BUILD_BINDINGS` option (default `OFF`) that pulls in `bindings/`; errors out if the shared library isn't enabled.

**`bindings/node`** — N-API addon via `node-addon-api` + `cmake-js`. `start()` runs Drogon on a background thread so the event loop keeps running. Route handlers are dispatched through `Napi::ThreadSafeFunction` because Drogon calls them from its own worker threads; async handlers are supported, with the Drogon thread waiting on a `std::promise` until the returned Promise settles. `db.query()` returns a Promise resolved from a `Napi::AsyncWorker`, so the event loop never blocks on I/O. Ships `index.d.ts`.

**`bindings/python`** — nanobind extension via `scikit-build-core`. Same surface in snake_case. `start()` blocks by default like Flask's `app.run()`, with `blocking=False` for a background thread. The GIL is acquired around every handler call and released for the duration of `db.query()`. Router methods double as decorators, so `@app.router.get("/path")` works.

**CI** — `bindings-node.yml` and `bindings-python.yml` at the repo root (workflows nested under a subdirectory aren't picked up by Actions). On a `v*` tag or manual dispatch: prebuilt `.node` binaries across OS × Node LTS uploaded as Release assets then `npm publish`; CPython 3.9–3.13 wheels via `cibuildwheel` (manylinux_2_28, musllinux_1_2, macOS, Windows x64) plus an sdist, then PyPI.

## Notes for review

- **Not built or run yet.** The binding sources were written against `dev`'s API and each symbol they call was checked to exist with a matching signature, but no compile or end-to-end test has been done. The CI workflows are the first real exercise of these build paths. Treat the code as unverified until a build runs.
- The bindings call the existing `getPathParamValue()` / `sendJSON()` / etc. directly rather than adding short aliases to the core header. An earlier draft added a `MantisResponse::json()` alias — that shadows the `json` type name inside a class whose `sendJSON()` default argument is `json::object()`, which is a name-lookup hazard, so the alias layer was dropped and the naming lives in the binding layer instead.
- `secretKey` / `secret_key` sets the `MB_JWT_SECRET` environment variable, since `MantisBase::create()` has no config key for it.
- `dev` is a presence-only flag in `MantisBase::create()`, so the bindings only add the key when the caller passes a truthy value.
- Package name availability on npm and PyPI should be confirmed before the first release tag.

## Out of scope

Hooks/event system (`onRecordCreate` etc. — doesn't exist yet), `mantisbase-sdk` REST clients (needs an OpenAPI spec first), QuickJS-NG (#118), Windows ARM64 binaries.